### PR TITLE
fix(cv): show warning modal when generating CV without events (BUG-004)

### DIFF
--- a/bugs/BUG-004-generate-cv-shows-stub-data-when-no-events-exist.md
+++ b/bugs/BUG-004-generate-cv-shows-stub-data-when-no-events-exist.md
@@ -1,0 +1,148 @@
+# BUG-004: Generate CV shows stub data when no events exist
+
+**Status**: FIXED  
+**Severity**: HIGH  
+**Reported**: 2026-01-20  
+**Fixed**: 2026-01-20  
+**Component**: `internal/cli/app/app.go`  
+**Affected Versions**: All versions with CV generation prior to fix  
+**Reporter**: User (via onboarding flow testing)
+
+---
+
+## Summary
+
+When a user deletes their database (or has a fresh install) and completes the onboarding wizard, selecting "Generate CV" from the menu shows fake stub/test data ("Test event for navigation integration") instead of a proper empty state message informing the user they need to add career events first.
+
+---
+
+## Steps to Reproduce
+
+1. Delete the database file: `rm ~/.kariya/events.db`
+2. Run KaRiya: `go run cmd/cli/main.go`
+3. Complete the onboarding wizard (enter name, email)
+4. From the main menu, select "Generate CV"
+5. Observe the CV generation wizard
+
+---
+
+## Expected Behavior
+
+A warning/info modal should appear with a message like:
+
+> **No Career Events**
+> 
+> You need to add career events before generating a CV.
+> 
+> Use 'Capture Event' from the main menu to record your achievements, projects, and career milestones.
+
+The user should be returned to the main menu after dismissing the modal (via Enter, Space, or Esc).
+
+---
+
+## Actual Behavior
+
+The CV generation wizard starts and shows fake stub data:
+- Event: "Test event for navigation integration" (ID: `ev-stub`)
+- Fact: "Test fact for navigation integration" (ID: `fact-stub`)
+
+This is misleading as users see fake data that doesn't belong to them.
+
+---
+
+## Root Cause
+
+In `internal/cli/app/app.go` lines 718-725, when registering the `generate_cv` intent, stub data is injected if no events/facts exist:
+
+```go
+events, err := careerService.GetEventRepository().List(ctx, careerrepo.ListFilters{Limit: 100})
+if err != nil || len(events) == 0 {
+    events = []*career.CareerEvent{{ID: "ev-stub", Text: "Test event for navigation integration", Date: time.Now()}}
+}
+facts, err := careerService.GetFactRepository().List(ctx, careerrepo.FactListFilters{Limit: 100})
+if err != nil || len(facts) == 0 {
+    facts = []*career.Fact{{ID: "fact-stub", Text: "Test fact for navigation integration", ...}}
+}
+```
+
+This was added in commit `bf5f3e6` (CV generation wizard modal implementation) as a workaround for navigation testing, but it now affects real users.
+
+---
+
+## Environment
+
+- OS: Linux (any)
+- Go version: 1.24+
+- Branch: `next`
+
+---
+
+## Severity
+
+- [ ] Critical - Application crash/data loss
+- [x] High - Major feature broken
+- [ ] Medium - Feature partially broken
+- [ ] Low - Minor issue/cosmetic
+
+**Rationale**: Users see fake data that could be confusing or misleading. The Generate CV feature doesn't properly handle the empty state, which is a core UX failure.
+
+---
+
+## Impact
+
+| Impact Area | Description |
+|-------------|-------------|
+| **User Confusion** | Users see fake "test" data they didn't create |
+| **Trust** | Users may not trust the CV generation if it shows bogus data |
+| **Onboarding UX** | New users completing onboarding are immediately shown broken behavior |
+| **Feature Accessibility** | No guidance on what to do to actually use CV generation |
+
+---
+
+## Proposed Fix
+
+1. **Remove stub data fallback** from `app.go` lines 718-725
+2. **Create `InfoModal` component** following the `DeleteConfirmModal` pattern
+3. **Add empty state check** in `handleMenuInput` before activating `generate_cv` intent
+4. **Show warning modal** when user has no career events, with guidance to use "Capture Event"
+5. **Dismiss modal** on Enter, Space, or Esc, returning user to main menu
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `internal/cli/components/info_modal.go` | New - Info/warning modal component |
+| `internal/cli/components/info_modal_test.go` | New - Tests for info modal |
+| `internal/cli/app/app.go` | Remove stub data, add modal field, add empty state check |
+| `internal/testutil/e2e/generate_cv_empty_state_e2e_test.go` | New - E2E regression test |
+
+---
+
+## Testing Checklist
+
+- [x] E2E test: Selecting "Generate CV" with no events shows warning modal
+- [x] E2E test: Modal does NOT show stub data
+- [x] E2E test: Esc dismisses modal and returns to menu
+- [x] E2E test: Enter dismisses modal and returns to menu
+- [x] E2E test: With events, Generate CV works normally (no modal)
+- [x] Unit test: InfoModal displays correct title and message
+- [x] Unit test: InfoModal dismisses on Enter, Space, Esc
+- [ ] Manual test: Delete database, complete onboarding, select Generate CV
+
+---
+
+## Related
+
+- Commit `bf5f3e6` - Added stub data as workaround
+- `internal/cli/components/delete_confirm_modal.go` - Pattern for modal component
+- `internal/cli/app/app.go:718-725` - Location of bug
+
+---
+
+## Notes
+
+The stub data was originally added for navigation testing during development. The proper fix is to handle the empty state gracefully with user feedback, not to inject fake data.
+
+---
+
+**Last Updated**: 2026-01-20

--- a/internal/cli/app/app.go
+++ b/internal/cli/app/app.go
@@ -752,7 +752,6 @@ func registerAllIntents(router *intents.DefaultIntentRouter, cliService *service
 	})
 
 	// GenerateCV
-	// GenerateCV
 	// BUG-004: Removed stub data fallback - empty state is now handled by showing
 	// an info modal in handleMenuInput before this intent is activated.
 	_ = router.RegisterIntent("generate_cv", func() intents.Intent {

--- a/internal/cli/app/app.go
+++ b/internal/cli/app/app.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"context"
-	"time"
 
 	"github.com/baphled/kariya/internal/cli/components"
 	"github.com/baphled/kariya/internal/cli/intents"
@@ -60,6 +59,10 @@ type Model struct {
 	// Onboarding wizard for first-run profile setup
 	onboardingWizard *components.OnboardingWizardModal
 	appConfig        *config.Config
+
+	// Info modal for blocking user feedback (empty state, etc.)
+	// See BUG-004: Shows warning when user tries to generate CV without events
+	infoModal *components.InfoModal
 }
 
 // MenuItem represents a menu option
@@ -169,6 +172,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		// Handle info modal dismissal first (highest priority)
+		// BUG-004: Info modal shows when user tries to generate CV without events
+		if m.infoModal != nil && m.infoModal.IsVisible() {
+			if m.infoModal.Update(msg) {
+				m.infoModal = nil // Dismissed
+			}
+			return m, nil // Consume all keys when modal is showing
+		}
+
 		switch msg.String() {
 		case "ctrl+c":
 			return m, tea.Quit
@@ -321,7 +333,15 @@ func (m *Model) View() string {
 	if m.state == StateOnboarding {
 		return m.viewOnboarding()
 	} else if m.state == StateMenu {
-		return m.viewMenu()
+		menuView := m.viewMenu()
+
+		// BUG-004: Overlay info modal if active (e.g., empty state warning)
+		if m.infoModal != nil && m.infoModal.IsVisible() {
+			modalView := m.infoModal.View()
+			return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, modalView)
+		}
+
+		return menuView
 	} else if m.state == StateIntent {
 		activeIntent := m.intentRouter.GetActiveIntent()
 		if activeIntent != nil {
@@ -426,6 +446,24 @@ func (m *Model) handleMenuInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter", " ":
 		// Select the current menu item
 		selectedItem := m.menuItems[m.selectedMenuIndex]
+
+		// BUG-004: Check for empty state conditions before activating certain intents
+		// Generate CV requires at least one career event to be meaningful
+		if selectedItem.Intent == "generate_cv" {
+			events, err := m.careerService.GetEventRepository().List(m.ctx, careerrepo.ListFilters{Limit: 1})
+			if err != nil || len(events) == 0 {
+				// Show informational modal instead of activating intent
+				m.infoModal = components.NewWarningInfoModal(
+					"No Career Events",
+					"You need to add career events before generating a CV.\n\n"+
+						"Use 'Capture Event' from the main menu to record your "+
+						"achievements, projects, and career milestones.",
+				)
+				m.infoModal.SetDimensions(m.width, m.height)
+				return m, nil
+			}
+		}
+
 		m.state = StateIntent
 		cmd, err := m.intentRouter.ActivateIntent(selectedItem.Intent, make(map[string]interface{}))
 		if err != nil {
@@ -714,14 +752,19 @@ func registerAllIntents(router *intents.DefaultIntentRouter, cliService *service
 	})
 
 	// GenerateCV
+	// GenerateCV
+	// BUG-004: Removed stub data fallback - empty state is now handled by showing
+	// an info modal in handleMenuInput before this intent is activated.
 	_ = router.RegisterIntent("generate_cv", func() intents.Intent {
 		events, err := careerService.GetEventRepository().List(ctx, careerrepo.ListFilters{Limit: 100})
-		if err != nil || len(events) == 0 {
-			events = []*career.CareerEvent{{ID: "ev-stub", Text: "Test event for navigation integration", Date: time.Now()}}
+		if err != nil {
+			log.Error("Failed to load events for CV generation: %v", err)
+			events = []*career.CareerEvent{}
 		}
 		facts, err := careerService.GetFactRepository().List(ctx, careerrepo.FactListFilters{Limit: 100})
-		if err != nil || len(facts) == 0 {
-			facts = []*career.Fact{{ID: "fact-stub", Text: "Test fact for navigation integration", CompetencyCategories: []string{"technical"}, RoleFit: "staff", AudienceRelevance: []string{"peer"}, SourceEventID: "ev-stub"}}
+		if err != nil {
+			log.Error("Failed to load facts for CV generation: %v", err)
+			facts = []*career.Fact{}
 		}
 		// Load user's profile config for narrative CV exports
 		var profileCfg *config.ProfileConfig

--- a/internal/cli/app/app_integration_test.go
+++ b/internal/cli/app/app_integration_test.go
@@ -25,7 +25,7 @@ var _ = Describe("App Menu Integration Tests", func() {
 	)
 
 	BeforeEach(func() {
-		_ = context.Background()
+		ctx := context.Background()
 		repo = careerrepo.NewMemoryRepository()
 		burstRepo := careerrepo.NewMemoryBurstRepository()
 		factRepo := careerrepo.NewMemoryFactRepository()
@@ -35,9 +35,11 @@ var _ = Describe("App Menu Integration Tests", func() {
 		svc.SetFactRepository(factRepo)
 		svc.SetSkillRepository(skillRepo)
 		cliService = service.NewCLIEventService(svc)
-		// Pre-populate burst/fact repositories with dummy entries to avoid nil panics
-		_ = burstRepo.Create(context.Background(), fixtures.Burst("b1", "e1", "e2"))
-		_ = factRepo.Create(context.Background(), fixtures.Fact("f1", "e1"))
+		// Pre-populate repositories with dummy entries to avoid nil panics and empty state modals
+		// BUG-004: Generate CV now shows a warning modal if no events exist
+		_ = repo.Create(ctx, &career.CareerEvent{ID: "e1", Text: "Test event", Date: time.Now()})
+		_ = burstRepo.Create(ctx, fixtures.Burst("b1", "e1", "e2"))
+		_ = factRepo.Create(ctx, fixtures.Fact("f1", "e1"))
 		model = app.NewModel(cliService, svc)
 		model.SkipOnboarding() // Skip onboarding for tests
 

--- a/internal/cli/components/info_modal.go
+++ b/internal/cli/components/info_modal.go
@@ -1,0 +1,266 @@
+package components
+
+import (
+	"strings"
+
+	"github.com/baphled/kariya/internal/cli/themes"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// InfoModalVariant defines the visual style variant of the modal.
+type InfoModalVariant int
+
+const (
+	// InfoModalInfo uses informational styling (teal/blue border).
+	InfoModalInfo InfoModalVariant = iota
+	// InfoModalWarning uses warning styling (amber/yellow border).
+	InfoModalWarning
+	// InfoModalSuccess uses success styling (green border).
+	InfoModalSuccess
+)
+
+// InfoModal is a reusable informational modal for displaying messages to the user.
+// Unlike DeleteConfirmModal, it has a single action: dismiss. It does not ask for
+// confirmation - it simply displays information and allows the user to acknowledge it.
+//
+// Usage:
+//
+//	modal := components.NewInfoModal("Title", "Message explaining something...")
+//	modal := components.NewWarningInfoModal("Warning Title", "Warning message...")
+//
+//	// In Update:
+//	if modal.Update(msg) {
+//	    // User dismissed the modal
+//	    modal = nil
+//	}
+//
+//	// In View:
+//	if modal != nil && modal.IsVisible() {
+//	    return modal.View()
+//	}
+//
+// Dismisses on: Enter, Space, Esc
+type InfoModal struct {
+	title   string
+	message string
+	visible bool
+	variant InfoModalVariant
+	theme   themes.Theme
+	width   int
+	height  int
+}
+
+// NewInfoModal creates a new info modal with informational styling (teal/blue border).
+//
+// Parameters:
+//   - title: Modal title (displayed prominently at top)
+//   - message: Message body (can include newlines for formatting)
+//
+// Returns a new InfoModal ready to use.
+func NewInfoModal(title, message string) *InfoModal {
+	return &InfoModal{
+		title:   title,
+		message: message,
+		visible: true,
+		variant: InfoModalInfo,
+		theme:   themes.NewDefaultTheme(),
+		width:   100,
+		height:  24,
+	}
+}
+
+// NewWarningInfoModal creates a new info modal with warning styling (amber/yellow border).
+// Use this when the message is a warning or caution to the user.
+//
+// Parameters:
+//   - title: Modal title (displayed prominently at top)
+//   - message: Warning message (can include newlines for formatting)
+//
+// Returns a new InfoModal with warning variant.
+func NewWarningInfoModal(title, message string) *InfoModal {
+	return &InfoModal{
+		title:   title,
+		message: message,
+		visible: true,
+		variant: InfoModalWarning,
+		theme:   themes.NewDefaultTheme(),
+		width:   100,
+		height:  24,
+	}
+}
+
+// NewSuccessInfoModal creates a new info modal with success styling (green border).
+// Use this when displaying a success or completion message.
+//
+// Parameters:
+//   - title: Modal title (displayed prominently at top)
+//   - message: Success message (can include newlines for formatting)
+//
+// Returns a new InfoModal with success variant.
+func NewSuccessInfoModal(title, message string) *InfoModal {
+	return &InfoModal{
+		title:   title,
+		message: message,
+		visible: true,
+		variant: InfoModalSuccess,
+		theme:   themes.NewDefaultTheme(),
+		width:   100,
+		height:  24,
+	}
+}
+
+// Init initializes the modal (required by BubbleTea lifecycle).
+func (m *InfoModal) Init() tea.Cmd {
+	return nil
+}
+
+// Update handles keyboard input for the info modal.
+//
+// Returns true if the modal was dismissed, false otherwise.
+//
+// The modal dismisses on:
+//   - Enter: acknowledges the message
+//   - Space: acknowledges the message
+//   - Esc: closes the modal
+func (m *InfoModal) Update(msg tea.Msg) bool {
+	if !m.visible {
+		return false
+	}
+
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return false
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "enter", " ", "esc":
+			// User dismissed the modal
+			m.visible = false
+			return true
+		}
+	}
+
+	return false
+}
+
+// View renders the info modal as a centered box.
+//
+// The modal displays:
+//   - Title (styled based on variant)
+//   - Message body
+//   - Dismissal instructions
+//
+// Returns empty string if modal is not visible.
+func (m *InfoModal) View() string {
+	if !m.visible {
+		return ""
+	}
+
+	// Get border color based on variant
+	borderColor := m.getBorderColor()
+
+	// Build footer with KeyBadge components
+	footer := RenderHelpFooter(m.theme,
+		NewKeyBadge("Enter/Esc", "Close"),
+	)
+
+	// Build modal content
+	var content strings.Builder
+
+	// Title (styled based on variant)
+	titleStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(borderColor).
+		MarginBottom(1)
+	content.WriteString(titleStyle.Render(m.title))
+	content.WriteString("\n\n")
+
+	// Message (wrapped to modal width)
+	messageStyle := lipgloss.NewStyle().
+		Width(50).
+		MarginBottom(1)
+	content.WriteString(messageStyle.Render(m.message))
+	content.WriteString("\n\n")
+
+	// Footer
+	content.WriteString(footer)
+
+	// Create modal box (centered, with border)
+	modalWidth := 60
+	if modalWidth > m.width-4 {
+		modalWidth = m.width - 4
+	}
+	if modalWidth < 40 {
+		modalWidth = 40
+	}
+
+	modalStyle := lipgloss.NewStyle().
+		Width(modalWidth).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(borderColor).
+		Background(m.theme.BackgroundColor()). // Solid background for overlay
+		Padding(1, 2).
+		Align(lipgloss.Center)
+
+	modalBox := modalStyle.Render(content.String())
+
+	return modalBox
+}
+
+// getBorderColor returns the appropriate border color based on variant.
+func (m *InfoModal) getBorderColor() lipgloss.Color {
+	switch m.variant {
+	case InfoModalWarning:
+		return m.theme.WarningColor()
+	case InfoModalSuccess:
+		return m.theme.SuccessColor()
+	case InfoModalInfo:
+		fallthrough
+	default:
+		return m.theme.InfoColor()
+	}
+}
+
+// IsVisible returns whether the modal is currently visible.
+func (m *InfoModal) IsVisible() bool {
+	return m.visible
+}
+
+// Show makes the modal visible.
+func (m *InfoModal) Show() {
+	m.visible = true
+}
+
+// Hide hides the modal.
+func (m *InfoModal) Hide() {
+	m.visible = false
+}
+
+// SetTheme sets the theme for the modal (useful for testing or custom themes).
+func (m *InfoModal) SetTheme(theme themes.Theme) {
+	m.theme = theme
+}
+
+// SetDimensions sets the terminal dimensions for responsive sizing.
+func (m *InfoModal) SetDimensions(width, height int) {
+	m.width = width
+	m.height = height
+}
+
+// GetTitle returns the modal title.
+func (m *InfoModal) GetTitle() string {
+	return m.title
+}
+
+// GetMessage returns the modal message.
+func (m *InfoModal) GetMessage() string {
+	return m.message
+}
+
+// GetVariant returns the modal variant.
+func (m *InfoModal) GetVariant() InfoModalVariant {
+	return m.variant
+}

--- a/internal/cli/components/info_modal_test.go
+++ b/internal/cli/components/info_modal_test.go
@@ -1,0 +1,175 @@
+package components_test
+
+import (
+	"github.com/baphled/kariya/internal/cli/components"
+	tea "github.com/charmbracelet/bubbletea"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("InfoModal", func() {
+	Describe("NewInfoModal", func() {
+		It("should create a visible modal with info variant", func() {
+			modal := components.NewInfoModal("Test Title", "Test message")
+
+			Expect(modal.IsVisible()).To(BeTrue())
+			Expect(modal.GetTitle()).To(Equal("Test Title"))
+			Expect(modal.GetMessage()).To(Equal("Test message"))
+			Expect(modal.GetVariant()).To(Equal(components.InfoModalInfo))
+		})
+	})
+
+	Describe("NewWarningInfoModal", func() {
+		It("should create a visible modal with warning variant", func() {
+			modal := components.NewWarningInfoModal("Warning Title", "Warning message")
+
+			Expect(modal.IsVisible()).To(BeTrue())
+			Expect(modal.GetTitle()).To(Equal("Warning Title"))
+			Expect(modal.GetMessage()).To(Equal("Warning message"))
+			Expect(modal.GetVariant()).To(Equal(components.InfoModalWarning))
+		})
+	})
+
+	Describe("NewSuccessInfoModal", func() {
+		It("should create a visible modal with success variant", func() {
+			modal := components.NewSuccessInfoModal("Success Title", "Success message")
+
+			Expect(modal.IsVisible()).To(BeTrue())
+			Expect(modal.GetTitle()).To(Equal("Success Title"))
+			Expect(modal.GetMessage()).To(Equal("Success message"))
+			Expect(modal.GetVariant()).To(Equal(components.InfoModalSuccess))
+		})
+	})
+
+	Describe("Update", func() {
+		var modal *components.InfoModal
+
+		BeforeEach(func() {
+			modal = components.NewInfoModal("Test", "Test message")
+		})
+
+		Context("when modal is visible", func() {
+			It("should dismiss on Enter key", func() {
+				dismissed := modal.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+				Expect(dismissed).To(BeTrue())
+				Expect(modal.IsVisible()).To(BeFalse())
+			})
+
+			It("should dismiss on Space key", func() {
+				dismissed := modal.Update(tea.KeyMsg{Type: tea.KeySpace})
+
+				Expect(dismissed).To(BeTrue())
+				Expect(modal.IsVisible()).To(BeFalse())
+			})
+
+			It("should dismiss on Esc key", func() {
+				dismissed := modal.Update(tea.KeyMsg{Type: tea.KeyEscape})
+
+				Expect(dismissed).To(BeTrue())
+				Expect(modal.IsVisible()).To(BeFalse())
+			})
+
+			It("should NOT dismiss on other keys", func() {
+				dismissed := modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+
+				Expect(dismissed).To(BeFalse())
+				Expect(modal.IsVisible()).To(BeTrue())
+			})
+
+			It("should handle WindowSizeMsg without dismissing", func() {
+				dismissed := modal.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+
+				Expect(dismissed).To(BeFalse())
+				Expect(modal.IsVisible()).To(BeTrue())
+			})
+		})
+
+		Context("when modal is hidden", func() {
+			BeforeEach(func() {
+				modal.Hide()
+			})
+
+			It("should not dismiss on Enter when already hidden", func() {
+				dismissed := modal.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+				Expect(dismissed).To(BeFalse())
+				Expect(modal.IsVisible()).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("View", func() {
+		It("should render title and message", func() {
+			modal := components.NewInfoModal("My Title", "My message content")
+			modal.SetDimensions(100, 30)
+
+			view := modal.View()
+
+			Expect(view).To(ContainSubstring("My Title"))
+			Expect(view).To(ContainSubstring("My message content"))
+		})
+
+		It("should render dismiss instructions", func() {
+			modal := components.NewInfoModal("Title", "Message")
+			modal.SetDimensions(100, 30)
+
+			view := modal.View()
+
+			Expect(view).To(ContainSubstring("Close"))
+		})
+
+		It("should return empty string when hidden", func() {
+			modal := components.NewInfoModal("Title", "Message")
+			modal.Hide()
+
+			view := modal.View()
+
+			Expect(view).To(BeEmpty())
+		})
+
+		It("should handle multiline messages", func() {
+			modal := components.NewInfoModal("Title", "Line 1\n\nLine 2\n\nLine 3")
+			modal.SetDimensions(100, 30)
+
+			view := modal.View()
+
+			Expect(view).To(ContainSubstring("Line 1"))
+			Expect(view).To(ContainSubstring("Line 2"))
+			Expect(view).To(ContainSubstring("Line 3"))
+		})
+	})
+
+	Describe("Visibility Controls", func() {
+		var modal *components.InfoModal
+
+		BeforeEach(func() {
+			modal = components.NewInfoModal("Test", "Test message")
+		})
+
+		It("should start visible", func() {
+			Expect(modal.IsVisible()).To(BeTrue())
+		})
+
+		It("should hide when Hide is called", func() {
+			modal.Hide()
+			Expect(modal.IsVisible()).To(BeFalse())
+		})
+
+		It("should show when Show is called after hide", func() {
+			modal.Hide()
+			modal.Show()
+			Expect(modal.IsVisible()).To(BeTrue())
+		})
+	})
+
+	Describe("Init", func() {
+		It("should return nil command", func() {
+			modal := components.NewInfoModal("Test", "Test message")
+
+			cmd := modal.Init()
+
+			Expect(cmd).To(BeNil())
+		})
+	})
+})

--- a/internal/cli/intents/generate_cv_navigation_test.go
+++ b/internal/cli/intents/generate_cv_navigation_test.go
@@ -13,6 +13,7 @@ var _ = Describe("GenerateCV Navigation", func() {
 	Describe("Navigation to GenerateCV Intent", func() {
 		BeforeEach(func() {
 			env = e2e.SetupWithMemory(GinkgoT())
+			env.PopulateTestData(3, 0, 0) // Add events to prevent empty state modal (BUG-004)
 		})
 
 		AfterEach(func() {
@@ -37,6 +38,7 @@ var _ = Describe("GenerateCV Navigation", func() {
 	Describe("Profile Selection State", func() {
 		BeforeEach(func() {
 			env = e2e.SetupWithMemory(GinkgoT())
+			env.PopulateTestData(3, 0, 0) // Add events to prevent empty state modal (BUG-004)
 			env.SelectIntentByName("generate_cv")
 		})
 
@@ -87,6 +89,7 @@ var _ = Describe("GenerateCV Navigation", func() {
 	Describe("Audience Selection State", func() {
 		BeforeEach(func() {
 			env = e2e.SetupWithMemory(GinkgoT())
+			env.PopulateTestData(3, 0, 0) // Add events to prevent empty state modal (BUG-004)
 			env.SelectIntentByName("generate_cv")
 			env.Confirm() // Select first profile
 		})
@@ -121,6 +124,7 @@ var _ = Describe("GenerateCV Navigation", func() {
 	Describe("Cancel at Each State", func() {
 		BeforeEach(func() {
 			env = e2e.SetupWithMemory(GinkgoT())
+			env.PopulateTestData(3, 0, 0) // Add events to prevent empty state modal (BUG-004)
 		})
 
 		AfterEach(func() {
@@ -153,6 +157,7 @@ var _ = Describe("GenerateCV Navigation", func() {
 	Describe("View Rendering", func() {
 		BeforeEach(func() {
 			env = e2e.SetupWithMemory(GinkgoT())
+			env.PopulateTestData(3, 0, 0) // Add events to prevent empty state modal (BUG-004)
 		})
 
 		AfterEach(func() {
@@ -190,6 +195,7 @@ var _ = Describe("GenerateCV Navigation", func() {
 	Describe("Vim-style Navigation", func() {
 		BeforeEach(func() {
 			env = e2e.SetupWithMemory(GinkgoT())
+			env.PopulateTestData(3, 0, 0) // Add events to prevent empty state modal (BUG-004)
 			env.SelectIntentByName("generate_cv")
 		})
 
@@ -229,6 +235,7 @@ var _ = Describe("GenerateCV Navigation", func() {
 	Describe("Arrow Key Navigation", func() {
 		BeforeEach(func() {
 			env = e2e.SetupWithMemory(GinkgoT())
+			env.PopulateTestData(3, 0, 0) // Add events to prevent empty state modal (BUG-004)
 			env.SelectIntentByName("generate_cv")
 		})
 
@@ -260,6 +267,7 @@ var _ = Describe("GenerateCV Navigation", func() {
 	Describe("Workflow Navigation", func() {
 		BeforeEach(func() {
 			env = e2e.SetupWithMemory(GinkgoT())
+			env.PopulateTestData(3, 0, 0) // Add events to prevent empty state modal (BUG-004)
 		})
 
 		AfterEach(func() {

--- a/internal/testutil/e2e/generate_cv_empty_state_e2e_test.go
+++ b/internal/testutil/e2e/generate_cv_empty_state_e2e_test.go
@@ -1,0 +1,153 @@
+package e2e_test
+
+import (
+	"time"
+
+	"github.com/baphled/kariya/internal/cli/app"
+	"github.com/baphled/kariya/internal/domain/career"
+	"github.com/baphled/kariya/internal/testutil/e2e"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// E2E Tests for Generate CV Empty State Handling (BUG-004)
+//
+// PURPOSE: Verify that when a user has no career events, selecting "Generate CV"
+// shows a helpful warning modal instead of stub/test data.
+//
+// BUG-004: Generate CV was showing fake "Test event for navigation integration"
+// stub data instead of informing users they need to add events first.
+//
+// Related:
+// - bugs/BUG-004-generate-cv-shows-stub-data-when-no-events-exist.md
+// - internal/cli/app/app.go (stub data removal)
+// - internal/cli/components/info_modal.go (new modal component)
+
+var _ = Describe("E2E Generate CV Empty State (BUG-004)", func() {
+	var env *e2e.TestEnv
+
+	Describe("when no career events exist", func() {
+		BeforeEach(func() {
+			// Setup with empty database (no events, no facts)
+			env = e2e.Setup(GinkgoT())
+			// Explicitly verify we have no events
+			Expect(env.GetEvents()).To(BeEmpty(), "Test setup should have no events")
+		})
+
+		AfterEach(func() {
+			env.Cleanup()
+		})
+
+		It("should show warning modal when selecting Generate CV", func() {
+			// Navigate to Generate CV menu item and select it
+			env.SelectIntentByName("generate_cv")
+
+			// Should show warning modal with helpful message
+			view := env.GetView()
+			Expect(view).To(ContainSubstring("No Career Events"),
+				"Should show 'No Career Events' title in modal")
+			Expect(view).To(ContainSubstring("Capture Event"),
+				"Should guide user to use 'Capture Event' feature")
+		})
+
+		It("should NOT show stub test data", func() {
+			env.SelectIntentByName("generate_cv")
+
+			// Must not show the old stub data that was injected
+			view := env.GetView()
+			Expect(view).NotTo(ContainSubstring("Test event for navigation"),
+				"Should NOT show stub test event data")
+			Expect(view).NotTo(ContainSubstring("ev-stub"),
+				"Should NOT show stub event ID")
+			Expect(view).NotTo(ContainSubstring("fact-stub"),
+				"Should NOT show stub fact ID")
+		})
+
+		It("should dismiss modal and return to menu on Esc", func() {
+			env.SelectIntentByName("generate_cv")
+
+			// Verify modal is showing
+			env.AssertViewContains("No Career Events")
+
+			// Press Esc to dismiss
+			env.Cancel()
+
+			// Should be back at menu
+			Expect(env.IsInMenuState()).To(BeTrue(),
+				"Should return to menu after dismissing modal with Esc")
+			env.AssertViewNotContains("No Career Events")
+		})
+
+		It("should dismiss modal and return to menu on Enter", func() {
+			env.SelectIntentByName("generate_cv")
+
+			// Verify modal is showing
+			env.AssertViewContains("No Career Events")
+
+			// Press Enter to dismiss
+			env.Confirm()
+
+			// Should be back at menu
+			Expect(env.IsInMenuState()).To(BeTrue(),
+				"Should return to menu after dismissing modal with Enter")
+			env.AssertViewNotContains("No Career Events")
+		})
+
+		It("should remain in menu state (not enter intent state)", func() {
+			env.SelectIntentByName("generate_cv")
+
+			// The modal overlays the menu, but we remain in StateMenu (not StateIntent)
+			// Note: IsInMenuState() checks view content which is replaced by modal,
+			// so we check the actual state instead
+			Expect(env.Model.GetState()).To(Equal(app.StateMenu),
+				"Should remain in menu state with modal overlay")
+		})
+	})
+
+	Describe("when career events exist", func() {
+		BeforeEach(func() {
+			env = e2e.Setup(GinkgoT())
+
+			// Add a real career event
+			env.AddEvent(&career.CareerEvent{
+				ID:      "event-real-1",
+				Text:    "Led team of 5 engineers on microservices migration project",
+				Date:    time.Now().AddDate(0, -1, 0), // 1 month ago
+				Company: "Test Company",
+				Project: "Migration Project",
+			})
+
+			// Verify event was added
+			Expect(env.GetEvents()).To(HaveLen(1), "Should have 1 event after setup")
+		})
+
+		AfterEach(func() {
+			env.Cleanup()
+		})
+
+		It("should allow Generate CV and proceed to wizard (no warning modal)", func() {
+			env.SelectIntentByName("generate_cv")
+
+			// Should NOT show warning modal
+			view := env.GetView()
+			Expect(view).NotTo(ContainSubstring("No Career Events"),
+				"Should NOT show empty state warning when events exist")
+
+			// Should be in the CV generation flow (intent active, not menu)
+			Expect(env.IsInMenuState()).To(BeFalse(),
+				"Should have left menu state to enter CV generation")
+		})
+
+		It("should show CV wizard content instead of warning", func() {
+			env.SelectIntentByName("generate_cv")
+
+			// Should show wizard content (profile selection or wizard modal)
+			view := env.GetView()
+			Expect(view).To(Or(
+				ContainSubstring("Profile"),
+				ContainSubstring("CV"),
+				ContainSubstring("Generate"),
+			), "Should show CV generation wizard content")
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Fixes BUG-004: When a user deletes their database and completes onboarding, selecting "Generate CV" now shows a helpful warning modal instead of fake stub data.

**Before**: Users saw confusing "Test event for navigation integration" stub data
**After**: Users see a clear warning modal guiding them to add career events first

## Changes

- Add `InfoModal` component for dismissible user feedback messages
- Show warning modal when user selects "Generate CV" without events
- Remove stub data fallback from `generate_cv` intent registration
- Guide users to use "Capture Event" to add career data first
- Update `app_integration_test` to pre-populate events for CV tests

## Testing

- 17 unit tests for `InfoModal` component
- 7 E2E tests for empty state behavior
- All 734 affected package tests pass

## Screenshots

When selecting "Generate CV" with no events:

```
╭────────────────────────────────────────────────────────────╮
│                                                            │
│                      No Career Events                      │
│                                                            │
│     You need to add career events before generating a      │
│     CV.                                                    │
│                                                            │
│     Use 'Capture Event' from the main menu to record       │
│     your achievements, projects, and career                │
│     milestones.                                            │
│                                                            │
│                      Enter/Esc  Close                      │
│                                                            │
╰────────────────────────────────────────────────────────────╯
```

## Related

- Bug report: `bugs/BUG-004-generate-cv-shows-stub-data-when-no-events-exist.md`