### PR TITLE
fix(lint): enforce huh restriction and fix errcheck in app.go

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -187,6 +187,8 @@ linters-settings:
       screens-no-intent-imports:
         files:
           - "**/screens/**/*.go"
+          - "**/screens/*.go"
+          - "!**/*_test.go"
         deny:
           - pkg: "github.com/baphled/kariya/internal/cli/intents"
             desc: |
@@ -268,30 +270,47 @@ linters-settings:
               See docs/UIKIT_GUIDE.md for theme integration.
 
       # =========================================================================
-      # FORMS: Enforce proper form patterns
+      # FORMS: huh can ONLY be imported in forms/ package
+      # Architecture: forms/ -> models/ -> components/ -> screens/ -> intents/
+      # Only forms/ is allowed to import huh directly
+      # Test files are excluded - they may need direct form creation for testing
       # =========================================================================
-      forms-proper-usage:
+      huh-restricted-to-forms:
         files:
           - "**/intents/**/*.go"
+          - "**/intents/*.go"
+          - "**/screens/**/*.go"
+          - "**/screens/*.go"
+          - "**/components/**/*.go"
+          - "**/components/*.go"
+          - "**/models/**/*.go"
+          - "**/models/*.go"
+          - "!**/*_test.go"
         deny:
           - pkg: "github.com/charmbracelet/huh"
             desc: |
-              PATTERN VIOLATION: Don't use huh.Form directly in intents.
+              ARCHITECTURE VIOLATION: huh can ONLY be imported in forms/ package.
 
-              Use the forms/ package wrappers instead:
+              Package-specific guidance:
+
+              INTENTS: Use models/ form wrappers:
+              - models.CaptureForm, models.MetadataForm, etc.
+              - forms.IsCompleted(f), forms.IsAborted(f) for state checks
+
+              SCREENS: Use base.FormScreen or forms/ builders:
+              - base.NewFormScreen(theme, form)
               - forms.NewThemedForm(theme, groups...)
-              - forms.NewFormWithHeight(height, groups...)
-              - forms.NewFormWithFixedConfirm(fields, confirm, w, h)
 
-              Or use models/ form wrappers:
-              - models.FormModel (wraps huh with theme integration)
+              COMPONENTS: Use forms/ builders:
+              - forms.NewInput(FieldConfig{...})
+              - forms.NewSelect(key, title, options...)
+              - forms.NewForm(groups...)
 
-              Direct huh.Form usage bypasses:
-              - Theme integration
-              - Standard form configuration
-              - Height/dimension handling
+              MODELS: Use forms.Form interface:
+              - Store forms.Form (not *huh.Form)
+              - Use forms.IsCompleted(), forms.IsAborted()
 
-              See internal/cli/forms/forms.go for available helpers.
+              See docs/FORMS_GUIDE.md and docs/rules/FORMS_WORKFLOW_GUIDE.md
 
       # =========================================================================
       # TABLES: Enforce TableBehavior usage
@@ -341,6 +360,7 @@ linters-settings:
           - github.com/charmbracelet
           - github.com/google/uuid
           - github.com/mattn/go-sqlite3
+          - modernc.org/sqlite
           - github.com/onsi/ginkgo/v2
           - github.com/onsi/gomega
           - github.com/spf13/cobra

--- a/internal/cli/app/app.go
+++ b/internal/cli/app/app.go
@@ -249,7 +249,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			// Temporarily register the edit intent
-			_ = m.intentRouter.RegisterIntent("capture_event_edit", func() intents.Intent {
+			//nolint:errcheck // RegisterIntent only errors on duplicate registration which cannot happen here
+			m.intentRouter.RegisterIntent("capture_event_edit", func() intents.Intent {
 				intent, err := intents.NewCaptureEventIntent(captureCtx)
 				if err != nil {
 					m.logger.Error("Failed to create CaptureEvent intent for editing: %v", err)
@@ -698,9 +699,12 @@ func createDefaultCVProfiles() []*intents.CVProfile {
 }
 
 // registerAllIntents registers all 10 intents with the router
+// All RegisterIntent calls below use nolint:errcheck because RegisterIntent only returns
+// an error on duplicate registration, which cannot happen in this initialization code.
 func registerAllIntents(router *intents.DefaultIntentRouter, cliService *service.CLIEventService, careerService *careerservice.Service, log *logger.Logger, ctx context.Context, cvGenService cv.CVGenerationService, cvExportService *cv.ExportService) {
 	// CaptureEvent
-	_ = router.RegisterIntent("capture_event", func() intents.Intent {
+	//nolint:errcheck // duplicate registration cannot happen here
+	router.RegisterIntent("capture_event", func() intents.Intent {
 		captureCtx := &intents.CaptureEventContext{
 			CaptureStrategy: "manual",
 			Metadata:        make(map[string]string),
@@ -716,7 +720,8 @@ func registerAllIntents(router *intents.DefaultIntentRouter, cliService *service
 	})
 
 	// BrowseTimeline
-	_ = router.RegisterIntent("browse_timeline", func() intents.Intent {
+	//nolint:errcheck // duplicate registration cannot happen here
+	router.RegisterIntent("browse_timeline", func() intents.Intent {
 		events, err := careerService.GetEventRepository().List(ctx, careerrepo.ListFilters{
 			Limit:     1000,
 			SortBy:    "date",
@@ -739,7 +744,8 @@ func registerAllIntents(router *intents.DefaultIntentRouter, cliService *service
 	})
 
 	// ManageSkills
-	_ = router.RegisterIntent("manage_skills", func() intents.Intent {
+	//nolint:errcheck // duplicate registration cannot happen here
+	router.RegisterIntent("manage_skills", func() intents.Intent {
 		skillsCtx := &intents.ManageSkillsContext{
 			Ctx:             ctx,
 			SkillRepository: careerService.GetSkillRepository(),
@@ -751,7 +757,8 @@ func registerAllIntents(router *intents.DefaultIntentRouter, cliService *service
 	// GenerateCV
 	// BUG-004: Removed stub data fallback - empty state is now handled by showing
 	// an info modal in handleMenuInput before this intent is activated.
-	_ = router.RegisterIntent("generate_cv", func() intents.Intent {
+	//nolint:errcheck // duplicate registration cannot happen here
+	router.RegisterIntent("generate_cv", func() intents.Intent {
 		events, err := careerService.GetEventRepository().List(ctx, careerrepo.ListFilters{Limit: 100})
 		if err != nil {
 			log.Error("Failed to load events for CV generation: %v", err)
@@ -797,7 +804,8 @@ func registerAllIntents(router *intents.DefaultIntentRouter, cliService *service
 	})
 
 	// ConfigureSystem
-	_ = router.RegisterIntent("configure_system", func() intents.Intent {
+	//nolint:errcheck // duplicate registration cannot happen here
+	router.RegisterIntent("configure_system", func() intents.Intent {
 		intent, err := intents.NewConfigureSystemIntent(ctx)
 		if err != nil {
 			log.Error("Failed to create ConfigureSystem intent: %v", err)
@@ -807,7 +815,8 @@ func registerAllIntents(router *intents.DefaultIntentRouter, cliService *service
 	})
 
 	// BurstManagement - Use helper constructor
-	_ = router.RegisterIntent("burst_management", func() intents.Intent {
+	//nolint:errcheck // duplicate registration cannot happen here
+	router.RegisterIntent("burst_management", func() intents.Intent {
 		burstRepo := careerService.GetBurstRepository()
 		burstCtx := intents.NewBurstManagementContext(careerService, burstRepo, ctx)
 		if burstCtx == nil {
@@ -823,7 +832,8 @@ func registerAllIntents(router *intents.DefaultIntentRouter, cliService *service
 	})
 
 	// FactManagement - Use helper constructor
-	_ = router.RegisterIntent("fact_management", func() intents.Intent {
+	//nolint:errcheck // duplicate registration cannot happen here
+	router.RegisterIntent("fact_management", func() intents.Intent {
 		factRepo := careerService.GetFactRepository()
 		factCtx := intents.NewFactManagementContext(factRepo, ctx)
 		if factCtx == nil {


### PR DESCRIPTION
## Summary

- Add depguard rule to enforce that `huh` (form library) can only be imported in the `forms/` package
- Fix errcheck warnings for RegisterIntent calls in app.go
- Add modernc.org/sqlite to allowed imports

## Changes

### Linter Configuration (`.golangci.yml`)

- **New Rule: `huh-restricted-to-forms`** - Enforces that `github.com/charmbracelet/huh` can only be imported in the `forms/` package. This aligns with the architecture documented in AGENTS.md:

| Package | Can Import `huh`? | Use Instead |
|---------|-------------------|-------------|
| `forms/` | **YES** (only place) | - |
| `models/` | **NO** | `forms.Form`, `forms.IsCompleted()` |
| `components/` | **NO** | `forms.NewXXX()` builders |
| `screens/` | **NO** | `base.FormScreen`, `forms/` |
| `intents/` | **NEVER** | `models.*Form` wrappers |

- **Fixed**: Added `modernc.org/sqlite` to allowed imports
- **Fixed**: Exclude test files from architecture rules

### App Initialization (`internal/cli/app/app.go`)

- Added `nolint:errcheck` comments for `RegisterIntent` calls with justification (error only occurs on duplicate registration which cannot happen in initialization code)

## Architecture Violations Surfaced

The new rule surfaces **5 existing architecture violations** that need to be addressed in future refactoring:

1. `internal/cli/intents/modals.go` - huh in intents
2. `internal/cli/models/burst_suggestion_new.go` - huh in models
3. `internal/cli/models/capture_form.go` - huh in models
4. `internal/cli/models/fact_editor_new.go` - huh in models
5. `internal/cli/screens/skills/form.go` - huh in screens

These violations existed before this PR - the new depguard rule now makes them visible for future cleanup.

## Testing

- Build passes
- Tests pass
- golangci-lint passes (except for the 5 surfaced architecture violations)