### PR TITLE
feat(cli): add architecture checks for screen/modal extraction

### DIFF
--- a/.github/workflows/architecture-lint.yml
+++ b/.github/workflows/architecture-lint.yml
@@ -41,17 +41,52 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Check Intent Architecture (PR - informational)
+      - name: Get changed files
         if: github.event_name == 'pull_request'
-        # For PRs, run full check but don't fail - legacy intents have pre-existing
-        # violations that will be fixed in separate migration PRs.
-        # Violations are displayed but don't block the PR.
+        id: changed-files
+        run: |
+          # Get list of changed files in this PR (intent and screen files only)
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | \
+            grep -E '^internal/cli/(intents|screens)/' | \
+            grep '\.go$' | \
+            grep -v '_test\.go$' || true)
+          
+          echo "Changed intent/screen files:"
+          echo "$CHANGED"
+          
+          # Store as output (space-separated for passing to script)
+          echo "files=$(echo $CHANGED | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          
+          # Check if any relevant files changed
+          if [ -n "$CHANGED" ]; then
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check Intent Architecture (PR - changed files only)
+        if: github.event_name == 'pull_request' && steps.changed-files.outputs.has_changes == 'true'
+        # Note: Some checks (#24-28) are global and will find pre-existing violations.
+        # These will be fixed in migration PRs. For now, we show violations but don't block.
         continue-on-error: true
         run: |
-          echo "Running architecture check (informational - violations shown but don't block PR)"
-          echo "Legacy intents have known violations that will be fixed in migration PRs."
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "Running architecture check on changed files:"
+          echo "${{ steps.changed-files.outputs.files }}"
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
           echo ""
-          make check-intent-architecture
+          echo "Note: Global checks (#24-28) may show pre-existing violations."
+          echo "These will be fixed in separate migration PRs."
+          echo ""
+          bash scripts/check-intent-architecture.sh ${{ steps.changed-files.outputs.files }}
+
+      - name: Skip Intent Architecture (PR - no relevant changes)
+        if: github.event_name == 'pull_request' && steps.changed-files.outputs.has_changes == 'false'
+        run: |
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+          echo "No intent/screen files changed in this PR."
+          echo "Skipping architecture check."
+          echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
       - name: Check Intent Architecture (Push - enforced)
         if: github.event_name == 'push'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,7 +347,7 @@ screens/{feature}/
 
 Run before every commit:
 ```bash
-make check-intent-architecture  # Checks #17-23 enforce structure
+make check-intent-architecture  # Checks #17-29 enforce structure
 ```
 
 **Automated Checks**:
@@ -358,6 +358,12 @@ make check-intent-architecture  # Checks #17-23 enforce structure
 - **Check #21**: UIKit component usage
 - **Check #22**: Deprecated models package usage
 - **Check #23**: Screens directory structure
+- **Check #24**: Modal structs in intents/ package (blocks any modal in intents)
+- **Check #25**: huh import location (blocks huh import outside forms/)
+- **Check #26**: Render methods in helpers.go (blocks >2 render methods)
+- **Check #27**: Screens existence for multi-state intents (blocks 2+ states without screens)
+- **Check #28**: Modal/Screen location validation (blocks structs in wrong packages)
+- **Check #29**: Naming convention enforcement (blocks non-compliant names)
 
 #### AI Agent Behavior
 
@@ -410,8 +416,50 @@ The AI agent MUST refuse code that:
 - Creates modals without solid background
 - Mutates intent state from screen code
 - Has circular package dependencies
+- **Defines modal structs in `intents/` package** (must be in `screens/*/modals/` or `uikit/feedback/`)
+- **Defines screen structs outside `screens/` package**
+- **Has >2 render methods in helpers.go** (must extract to screens)
+- **Has 2+ states without screens directory** (must extract screens)
+- **Uses wrong naming conventions** (Screen suffix, Modal suffix, underscore packages)
 
 **Reference**: [Intent Architecture Guide](docs/INTENT_ARCHITECTURE_GUIDE.md)
+
+---
+
+### Naming Conventions (STRICTLY ENFORCED)
+
+#### Screen Naming
+
+| Aspect | Convention | Example |
+|--------|------------|---------|
+| Package | `screens/{feature_name}/` (underscore) | `screens/fact_management/` |
+| File | `{type}.go` | `list.go`, `detail.go`, `form.go` |
+| Struct | `{Entity}{Type}Screen` | `FactListScreen`, `FactDetailScreen` |
+| Constructor | `New{StructName}()` | `NewFactListScreen()` |
+
+**Screen Types**: `List`, `Detail`, `Form`, `Delete`, `Select`, `Confirm`, `Preview`, `Review`
+
+#### Modal Naming
+
+| Aspect | Convention | Example |
+|--------|------------|---------|
+| Package | `screens/{feature}/modals/` | `screens/fact_management/modals/` |
+| File | `{action}_modal.go` | `edit_modal.go`, `filter_modal.go` |
+| Struct | `{Action}Modal` | `EditModal`, `FilterModal` |
+| Constructor | `New{StructName}()` | `NewEditModal()` |
+
+**Modal Types**: `Edit`, `Filter`, `Sort`, `Search`, `Confirm`, `Delete`, `Detail`, `QuickAdd`
+
+**Allowed Modal Locations**:
+- `internal/cli/uikit/feedback/` (reusable modals)
+- `internal/cli/screens/{feature}/modals/` (feature-specific)
+- `internal/cli/components/` (legacy, deprecated)
+
+**FORBIDDEN Modal Locations**:
+- `internal/cli/intents/` - **NEVER**
+- `internal/cli/models/` - **NEVER**
+
+**Reference**: [Screen Naming](docs/conventions/SCREEN_NAMING.md), [Modal Naming](docs/conventions/MODAL_NAMING.md)
 
 ---
 
@@ -1100,6 +1148,8 @@ make ai-commit FILE=/tmp/commit.txt
 | Modals | [MODAL_PATTERNS.md](docs/MODAL_PATTERNS.md) |
 | Intent architecture | [INTENT_ARCHITECTURE_GUIDE.md](docs/INTENT_ARCHITECTURE_GUIDE.md) |
 | Error handling | [ERROR_HANDLING_GUIDE.md](docs/guides/ERROR_HANDLING_GUIDE.md) |
+| Screen naming | [SCREEN_NAMING.md](docs/conventions/SCREEN_NAMING.md) |
+| Modal naming | [MODAL_NAMING.md](docs/conventions/MODAL_NAMING.md) |
 
 ### Troubleshooting
 

--- a/docs/conventions/MODAL_NAMING.md
+++ b/docs/conventions/MODAL_NAMING.md
@@ -1,0 +1,248 @@
+# Modal Naming Convention
+
+This document defines the standard naming conventions for modals in the KaRiya codebase.
+
+## Overview
+
+Modals are overlay UI components that appear above the main screen content. They are used for confirmations, forms, filters, and other focused interactions. Modals must be placed in approved locations and follow strict naming conventions.
+
+## Allowed Locations
+
+Modals may ONLY be defined in the following locations:
+
+| Location | Purpose | When to Use |
+|----------|---------|-------------|
+| `internal/cli/uikit/feedback/` | Reusable/generic modals | Confirm, Error, Loading, Success, Warning |
+| `internal/cli/screens/{feature}/modals/` | Feature-specific modals | Filter, Sort, Search, Edit for specific feature |
+| `internal/cli/components/` | Legacy (deprecated) | Do NOT add new modals here |
+
+### Forbidden Locations
+
+Modals MUST NOT be defined in:
+
+| Location | Reason |
+|----------|--------|
+| `internal/cli/intents/` | Violates layer separation |
+| `internal/cli/models/` | Package is deprecated |
+| Any other location | Not in approved list |
+
+## Directory Structure
+
+### Feature-Specific Modals
+
+```
+internal/cli/screens/{feature}/modals/
+├── edit_modal.go      # EditModal
+├── filter_modal.go    # FilterModal
+├── sort_modal.go      # SortModal
+├── search_modal.go    # SearchModal
+├── delete_modal.go    # DeleteModal
+├── detail_modal.go    # DetailModal
+└── helpers.go         # Shared modal utilities
+```
+
+### UIKit Feedback Modals
+
+```
+internal/cli/uikit/feedback/
+├── confirm_modal.go   # ConfirmModal
+├── error_modal.go     # (via NewErrorModal)
+├── help_modal.go      # HelpModal
+├── info_modal.go      # InfoModal
+├── detail_modal.go    # DetailModal
+└── modal.go           # Base modal types
+```
+
+## Naming Rules
+
+### File Naming
+
+| Rule | Convention | Example |
+|------|------------|---------|
+| Pattern | `{action}_modal.go` | `edit_modal.go`, `filter_modal.go` |
+| Lowercase | All lowercase with underscores | `quick_add_modal.go` |
+| Suffix | Always ends with `_modal.go` | `delete_modal.go` |
+
+### Struct Naming
+
+| Rule | Convention | Example |
+|------|------------|---------|
+| Pattern | `{Action}Modal` | `EditModal`, `FilterModal` |
+| No feature prefix | Package provides context | `EditModal` NOT `FactEditModal` |
+| Suffix | Always ends with `Modal` | `FilterModal` NOT `Filter` |
+| PascalCase | Use PascalCase | `QuickAddModal` |
+
+### Constructor Naming
+
+| Rule | Convention | Example |
+|------|------------|---------|
+| Pattern | `New{StructName}()` | `NewEditModal()` |
+| Match struct | Constructor matches struct name | `NewFilterModal()` for `FilterModal` |
+
+## Modal Types
+
+| Type | Purpose | File Name | Struct Example |
+|------|---------|-----------|----------------|
+| `Edit` | Edit existing item | `edit_modal.go` | `EditModal` |
+| `Filter` | Filter list items | `filter_modal.go` | `FilterModal` |
+| `Sort` | Sort options | `sort_modal.go` | `SortModal` |
+| `Search` | Text search | `search_modal.go` | `SearchModal` |
+| `Confirm` | Confirmation dialog | `confirm_modal.go` | `ConfirmModal` |
+| `Delete` | Delete confirmation | `delete_modal.go` | `DeleteModal` |
+| `Detail` | View item details | `detail_modal.go` | `DetailModal` |
+| `QuickAdd` | Quick add form | `quick_add_modal.go` | `QuickAddModal` |
+| `Help` | Help overlay | `help_modal.go` | `HelpModal` |
+
+## One Struct Per File Rule
+
+Each modal file must contain exactly ONE modal struct (except `helpers.go`).
+
+```go
+// CORRECT: One struct per file
+// File: screens/timeline/modals/filter_modal.go
+type FilterModal struct {
+    // ...
+}
+
+// WRONG: Multiple structs in one file
+// File: screens/timeline/modals/detail_modal.go
+type EventDetailModal struct { ... }
+type SkillsDetailModal struct { ... }  // VIOLATION - split into separate files
+```
+
+## Examples
+
+### Feature-Specific Modal
+
+```go
+// File: screens/fact_management/modals/edit_modal.go
+package modals
+
+import (
+    "github.com/baphled/kariya/internal/cli/forms"
+    "github.com/baphled/kariya/internal/domain/career"
+)
+
+// EditModal handles editing of fact details.
+type EditModal struct {
+    visible  bool
+    form     forms.Form
+    original *career.Fact
+    modified *career.Fact
+}
+
+// NewEditModal creates a new fact editing modal.
+func NewEditModal(fact *career.Fact) *EditModal {
+    return &EditModal{
+        original: fact,
+        modified: copyFact(fact),
+        form:     forms.NewFactEditForm(fact),
+    }
+}
+
+func (m *EditModal) IsVisible() bool {
+    return m.visible
+}
+
+func (m *EditModal) Show() {
+    m.visible = true
+}
+
+func (m *EditModal) Hide() {
+    m.visible = false
+}
+```
+
+### Using UIKit Feedback Modals
+
+```go
+// In intent code
+import "github.com/baphled/kariya/internal/cli/uikit/feedback"
+
+// For confirmations, use feedback package
+deleteModal := feedback.NewConfirmModal(
+    "Delete Fact",
+    "Are you sure you want to delete this fact?",
+).WithVariant(feedback.ConfirmDestructive)
+
+// For errors
+errorModal := feedback.NewErrorModal("Operation failed", err.Error())
+
+// For success
+successModal := feedback.NewSuccessModal("Fact saved successfully")
+```
+
+## huh Import Restriction
+
+The `huh` library (form library) should NOT be directly imported in modal files. Use the `forms/` package instead.
+
+```go
+// WRONG: Direct huh import
+import "github.com/charmbracelet/huh"
+
+type EditModal struct {
+    form *huh.Form  // VIOLATION
+}
+
+// CORRECT: Use forms package
+import "github.com/baphled/kariya/internal/cli/forms"
+
+type EditModal struct {
+    form forms.Form  // Uses forms package wrapper
+}
+```
+
+## Enforcement
+
+These conventions are enforced by multiple checks in `scripts/check-intent-architecture.sh`:
+
+| Check | What It Catches |
+|-------|-----------------|
+| #24 | Modal structs in intents/ package |
+| #25 | Direct huh import in wrong locations |
+| #28 | Modal structs in wrong locations |
+| #29 | Modal naming convention violations |
+
+Run to verify:
+```bash
+make check-intent-architecture
+```
+
+## Migration Guide
+
+If you have modals in the wrong location:
+
+1. Create the target directory:
+   ```bash
+   mkdir -p internal/cli/screens/{feature}/modals/
+   ```
+
+2. Move the modal file:
+   ```bash
+   mv internal/cli/intents/modals.go internal/cli/screens/{feature}/modals/edit_modal.go
+   ```
+
+3. Update the package declaration:
+   ```go
+   package modals  // NOT package intents
+   ```
+
+4. Update imports in intents:
+   ```go
+   import "github.com/baphled/kariya/internal/cli/screens/{feature}/modals"
+   ```
+
+5. Update struct references:
+   ```go
+   // OLD
+   editModal *intents.EditFactModal
+   
+   // NEW
+   editModal *modals.EditModal
+   ```
+
+## Related Documentation
+
+- [SCREEN_NAMING.md](SCREEN_NAMING.md) - Screen naming conventions
+- [INTENT_ARCHITECTURE_GUIDE.md](../INTENT_ARCHITECTURE_GUIDE.md) - Overall architecture
+- [FORMS_GUIDE.md](../FORMS_GUIDE.md) - Forms usage guide

--- a/docs/conventions/SCREEN_NAMING.md
+++ b/docs/conventions/SCREEN_NAMING.md
@@ -1,0 +1,136 @@
+# Screen Naming Convention
+
+This document defines the standard naming conventions for screens in the KaRiya codebase.
+
+## Overview
+
+Screens are UI components that represent distinct views within an intent workflow. They are located in the `internal/cli/screens/` package and follow strict naming conventions to ensure consistency and maintainability.
+
+## Directory Structure
+
+```
+internal/cli/screens/{feature}/
+├── list.go          # {Entity}ListScreen
+├── detail.go        # {Entity}DetailScreen
+├── form.go          # {Entity}FormScreen
+├── delete.go        # {Entity}DeleteScreen
+├── select.go        # {Entity}SelectScreen
+├── confirm.go       # {Entity}ConfirmScreen
+├── preview.go       # {Entity}PreviewScreen
+├── review.go        # {Entity}ReviewScreen
+└── modals/          # Feature-specific modals (see MODAL_NAMING.md)
+    ├── edit_modal.go
+    ├── filter_modal.go
+    └── helpers.go
+```
+
+## Naming Rules
+
+### Package Naming
+
+| Rule | Convention | Example |
+|------|------------|---------|
+| Directory name | `{feature_name}/` (underscore) | `fact_management/`, `burst_management/` |
+| Package name | Same as directory | `package fact_management` |
+| No hyphens | Use underscore, not hyphen | `fact_management/` NOT `fact-management/` |
+
+### File Naming
+
+| Rule | Convention | Example |
+|------|------------|---------|
+| Pattern | `{type}.go` | `list.go`, `detail.go`, `form.go` |
+| Alternative | `{entity}_{type}.go` | `event_list.go`, `skill_form.go` |
+| Lowercase | All lowercase with underscores | `delete_confirm.go` |
+| No suffix | Do not add `_screen.go` suffix | `list.go` NOT `list_screen.go` |
+
+### Struct Naming
+
+| Rule | Convention | Example |
+|------|------------|---------|
+| Pattern | `{Entity}{Type}Screen` | `FactListScreen`, `SkillDetailScreen` |
+| Entity | Short, singular entity name | `Fact`, `Skill`, `Burst`, `Event` |
+| Type | Screen purpose | `List`, `Detail`, `Form`, `Delete`, `Select` |
+| Suffix | Always ends with `Screen` | `FactListScreen` NOT `FactList` |
+| PascalCase | Use PascalCase | `FactListScreen` NOT `Fact_List_Screen` |
+
+### Constructor Naming
+
+| Rule | Convention | Example |
+|------|------------|---------|
+| Pattern | `New{StructName}()` | `NewFactListScreen()` |
+| Match struct | Constructor matches struct name | `NewSkillDetailScreen()` for `SkillDetailScreen` |
+
+## Screen Types
+
+| Type | Purpose | File Name | Struct Example |
+|------|---------|-----------|----------------|
+| `List` | Display list/table of items | `list.go` | `FactListScreen` |
+| `Detail` | Display single item details | `detail.go` | `FactDetailScreen` |
+| `Form` | Create or edit item | `form.go` | `FactFormScreen` |
+| `Delete` | Delete confirmation | `delete.go` | `FactDeleteScreen` |
+| `Select` | Selection picker | `select.go` | `FactSelectScreen` |
+| `Confirm` | Generic confirmation | `confirm.go` | `FactConfirmScreen` |
+| `Preview` | Preview before action | `preview.go` | `FactPreviewScreen` |
+| `Review` | Review changes | `review.go` | `FactReviewScreen` |
+
+## Examples
+
+### Fact Management Screens
+
+```
+screens/fact_management/
+├── list.go       # FactListScreen
+├── detail.go     # FactDetailScreen
+├── form.go       # FactFormScreen
+├── delete.go     # FactDeleteScreen
+└── modals/
+    └── edit_modal.go  # EditModal
+```
+
+```go
+// File: screens/fact_management/list.go
+package fact_management
+
+type FactListScreen struct {
+    *base.BaseScreen
+    table *behaviors.TableBehavior[*domain.Fact]
+}
+
+func NewFactListScreen(facts []*domain.Fact) *FactListScreen {
+    // ...
+}
+```
+
+### Timeline Screens (Reference Implementation)
+
+```
+screens/timeline/
+├── event_list.go         # TimelineEventListScreen
+├── event_detail.go       # TimelineEventDetailScreen
+├── event_delete_confirm.go # EventDeleteConfirmScreen
+└── modals/
+    ├── filter_modal.go   # FilterModal
+    ├── sort_modal.go     # SortModal
+    ├── search_modal.go   # SearchModal
+    ├── edit_modal.go     # EditModal
+    └── helpers.go
+```
+
+## Enforcement
+
+These conventions are enforced by Check #29 in `scripts/check-intent-architecture.sh`:
+
+- Screen structs must end with `Screen`
+- Package names must use underscore (not hyphen)
+- Violations block commits
+
+Run to verify:
+```bash
+make check-intent-architecture
+```
+
+## Related Documentation
+
+- [MODAL_NAMING.md](MODAL_NAMING.md) - Modal naming conventions
+- [INTENT_ARCHITECTURE_GUIDE.md](../INTENT_ARCHITECTURE_GUIDE.md) - Overall architecture
+- [INTENT_DEVELOPMENT_CHECKLIST.md](../checklists/INTENT_DEVELOPMENT_CHECKLIST.md) - Development checklist

--- a/docs/tasks/MIGRATE_INTENTS_MODALS.md
+++ b/docs/tasks/MIGRATE_INTENTS_MODALS.md
@@ -1,0 +1,181 @@
+# Migration Task: Move Modals from intents/modals.go
+
+## Overview
+
+The file `internal/cli/intents/modals.go` contains modal structs that violate the architecture rules. This task tracks the migration of these modals to their correct locations.
+
+## Current Violations
+
+| Check | Violation | File |
+|-------|-----------|------|
+| #24 | Modal structs in intents/ package | `intents/modals.go` |
+| #25 | Direct huh import in intents | `intents/modals.go:9` |
+| #28 | Modal structs in wrong location | `intents/modals.go` |
+
+## Modals to Migrate
+
+### 1. EditBurstModal
+
+| Attribute | Current | Target |
+|-----------|---------|--------|
+| File | `intents/modals.go` | `screens/burst_management/modals/edit_modal.go` |
+| Package | `intents` | `modals` |
+| Struct | `EditBurstModal` | `EditModal` |
+| Constructor | `NewEditBurstModal()` | `NewEditModal()` |
+
+### 2. EditFactModal
+
+| Attribute | Current | Target |
+|-----------|---------|--------|
+| File | `intents/modals.go` | `screens/fact_management/modals/edit_modal.go` |
+| Package | `intents` | `modals` |
+| Struct | `EditFactModal` | `EditModal` |
+| Constructor | `NewEditFactModal()` | `NewEditModal()` |
+
+## Migration Steps
+
+### Phase 1: Create Target Directories
+
+```bash
+mkdir -p internal/cli/screens/burst_management/modals
+mkdir -p internal/cli/screens/fact_management/modals
+```
+
+### Phase 2: Migrate EditBurstModal
+
+1. Create new file:
+   ```go
+   // File: internal/cli/screens/burst_management/modals/edit_modal.go
+   package modals
+   
+   import (
+       "github.com/baphled/kariya/internal/cli/forms"
+       "github.com/baphled/kariya/internal/domain/career"
+   )
+   
+   // EditModal handles inline editing of burst details.
+   type EditModal struct {
+       // ... fields from EditBurstModal
+   }
+   
+   func NewEditModal(burst *career.Burst) *EditModal {
+       // ... implementation
+   }
+   ```
+
+2. Refactor to use `forms/` package instead of direct `huh` import
+
+3. Update references in `intents/burst_management/`:
+   ```go
+   // OLD
+   import "github.com/baphled/kariya/internal/cli/intents"
+   editModal *intents.EditBurstModal
+   
+   // NEW
+   import "github.com/baphled/kariya/internal/cli/screens/burst_management/modals"
+   editModal *modals.EditModal
+   ```
+
+4. Update constructor calls:
+   ```go
+   // OLD
+   i.editModal = intents.NewEditBurstModal(burst)
+   
+   // NEW
+   i.editModal = modals.NewEditModal(burst)
+   ```
+
+### Phase 3: Migrate EditFactModal
+
+1. Create new file:
+   ```go
+   // File: internal/cli/screens/fact_management/modals/edit_modal.go
+   package modals
+   
+   import (
+       "github.com/baphled/kariya/internal/cli/forms"
+       "github.com/baphled/kariya/internal/domain/career"
+   )
+   
+   // EditModal handles inline editing of fact details.
+   type EditModal struct {
+       // ... fields from EditFactModal
+   }
+   
+   func NewEditModal(fact *career.Fact) *EditModal {
+       // ... implementation
+   }
+   ```
+
+2. Refactor to use `forms/` package instead of direct `huh` import
+
+3. Update references in `intents/fact_management/`:
+   ```go
+   // OLD
+   import "github.com/baphled/kariya/internal/cli/intents"
+   editModal *intents.EditFactModal
+   
+   // NEW
+   import "github.com/baphled/kariya/internal/cli/screens/fact_management/modals"
+   editModal *modals.EditModal
+   ```
+
+### Phase 4: Cleanup
+
+1. Remove `intents/modals.go` after all migrations complete
+2. Verify no remaining references to old modal types
+3. Run `make check-intent-architecture` to confirm violations resolved
+
+### Phase 5: Additional Fact Management Work
+
+The fact_management intent also needs screens extracted (Check #26, #27):
+
+1. Create screens:
+   ```
+   screens/fact_management/
+   ├── list.go       # FactListScreen (from helpers.go getStateContent)
+   ├── detail.go     # FactDetailScreen (from helpers.go getViewFactContent)
+   ├── form.go       # FactFormScreen (from helpers.go getEditorContent)
+   ├── delete.go     # FactDeleteScreen (from helpers.go getDeleteConfirmContent)
+   └── modals/
+       └── edit_modal.go  # EditModal (migrated above)
+   ```
+
+2. Update `fact_management/helpers.go` to delegate to screens
+3. Update `fact_management/intent.go` to orchestrate screens
+
+## Acceptance Criteria
+
+- [ ] `internal/cli/intents/modals.go` deleted
+- [ ] `EditBurstModal` migrated to `screens/burst_management/modals/edit_modal.go`
+- [ ] `EditFactModal` migrated to `screens/fact_management/modals/edit_modal.go`
+- [ ] No direct `huh` imports in migrated modals (use `forms/` package)
+- [ ] All references updated in intents
+- [ ] `make check-intent-architecture` passes with no violations
+- [ ] All tests pass
+
+## Dependencies
+
+This migration should be completed BEFORE:
+- Any new features added to burst_management intent
+- Any new features added to fact_management intent
+- Enabling checks #24, #25, #27, #28 as blocking in CI
+
+## Related Documentation
+
+- [MODAL_NAMING.md](../conventions/MODAL_NAMING.md) - Modal naming conventions
+- [SCREEN_NAMING.md](../conventions/SCREEN_NAMING.md) - Screen naming conventions
+- [INTENT_ARCHITECTURE_GUIDE.md](../INTENT_ARCHITECTURE_GUIDE.md) - Architecture rules
+
+## Priority
+
+**HIGH** - Blocks enforcement of new architecture checks.
+
+## Estimated Effort
+
+- EditBurstModal migration: 1-2 hours
+- EditFactModal migration: 1-2 hours
+- Fact management screens extraction: 4-6 hours
+- Testing and verification: 1-2 hours
+
+**Total: 7-12 hours**

--- a/scripts/check-intent-architecture.sh
+++ b/scripts/check-intent-architecture.sh
@@ -24,8 +24,8 @@ if [ $# -gt 0 ]; then
     # Files passed as arguments - filter to only intent .go files
     INTENT_FILES=""
     for arg in "$@"; do
-        # Only include .go files in intents/ directory (not test files)
-        if [[ "$arg" == internal/cli/intents/*.go && "$arg" != *_test.go ]]; then
+        # Only include .go files under intents/ directory (including subdirectories, not test files)
+        if [[ "$arg" == internal/cli/intents/* && "$arg" == *.go && "$arg" != *_test.go ]]; then
             INTENT_FILES="$INTENT_FILES $arg"
         fi
     done
@@ -1355,8 +1355,9 @@ if [ -n "$SUBDIRS" ]; then
         INTENT_NAME=$(basename "$intent_dir")
         
         if [ -f "$HELPERS_FILE" ]; then
-            # Count render/view content methods
-            RENDER_METHODS=$(grep -E "func.*\) get.*Content|func.*\) render|func.*\) view" "$HELPERS_FILE" 2>/dev/null | wc -l)
+            # Count render/view content methods (exclude getContextHelp, getBreadcrumbs, etc.)
+            # Match: getStateContent, getViewContent, getEditorContent, renderX, viewX
+            RENDER_METHODS=$(grep -E "func.*\) (get[A-Z][a-zA-Z]*Content|render[A-Z]|view[A-Z])\(" "$HELPERS_FILE" 2>/dev/null | grep -v "getContextHelp\|getBreadcrumbs" | wc -l)
             
             if [ "$RENDER_METHODS" -gt 2 ]; then
                 echo -e "${RED}❌ VIOLATION: Too many render methods in helpers.go${NC}"
@@ -1364,7 +1365,7 @@ if [ -n "$SUBDIRS" ]; then
                 echo "   Rule: Render logic must be in screens/ package"
                 echo ""
                 echo "   Found methods:"
-                grep -nE "func.*\) get.*Content|func.*\) render|func.*\) view" "$HELPERS_FILE" 2>/dev/null | head -10 | sed 's/^/   /' || true
+                grep -nE "func.*\) (get[A-Z][a-zA-Z]*Content|render[A-Z]|view[A-Z])\(" "$HELPERS_FILE" 2>/dev/null | grep -v "getContextHelp\|getBreadcrumbs" | head -10 | sed 's/^/   /' || true
                 echo ""
                 echo "   Required action:"
                 echo "   1. Create screens/$INTENT_NAME/ directory"
@@ -1445,7 +1446,8 @@ if [ -n "$SUBDIRS" ]; then
                     echo "   1. Create internal/cli/screens/$INTENT_NAME/"
                     echo "   2. Create screen files for each state:"
                     grep "State.*=.*\"" "$CONSTANTS_FILE" 2>/dev/null | head -10 | while read -r line; do
-                        STATE=$(echo "$line" | grep -oP 'State\w+' | head -1)
+                        # Use sed instead of grep -oP for portability (macOS/BSD).
+                        STATE=$(printf '%s\n' "$line" | sed -n 's/.*\(State[[:alnum:]_]*\).*/\1/p' | head -1)
                         echo "      - $STATE -> corresponding screen"
                     done
                     echo "   3. Extract render methods from helpers.go to screens"

--- a/scripts/check-intent-architecture.sh
+++ b/scripts/check-intent-architecture.sh
@@ -21,15 +21,27 @@ WARNINGS=0
 
 # Determine which files to check
 if [ $# -gt 0 ]; then
-    # Files passed as arguments - only check those
-    INTENT_FILES="$*"
+    # Files passed as arguments - filter to only intent .go files
+    INTENT_FILES=""
+    for arg in "$@"; do
+        # Only include .go files in intents/ directory (not test files)
+        if [[ "$arg" == internal/cli/intents/*.go && "$arg" != *_test.go ]]; then
+            INTENT_FILES="$INTENT_FILES $arg"
+        fi
+    done
+    INTENT_FILES=$(echo "$INTENT_FILES" | xargs)  # Trim whitespace
+    
     CHECK_MODE="changed"
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo "🏛️  INTENT ARCHITECTURE ENFORCEMENT (Changed Files)"
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
-    echo "Checking ${#} changed files..."
+    if [ -z "$INTENT_FILES" ]; then
+        echo "No intent files in changed files. Running global checks only..."
+    else
+        echo "Checking intent files: $INTENT_FILES"
+    fi
     echo ""
 else
     # No arguments - scan all intent files
@@ -1231,13 +1243,415 @@ fi
 echo ""
 
 # ============================================
+# 24. MODAL STRUCTS IN INTENTS PACKAGE
+# ============================================
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "24. MODAL STRUCTS IN INTENTS PACKAGE"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Check for modal structs defined ANYWHERE in intents/ package (not just *_intent.go)
+INTENTS_ALL_FILES=$(find internal/cli/intents -name "*.go" -not -name "*_test.go" 2>/dev/null || true)
+
+for file in $INTENTS_ALL_FILES; do
+    # Skip subdirectory intent files (they're checked by other rules)
+    FILENAME=$(basename "$file")
+    DIRNAME=$(dirname "$file")
+    
+    # Check for modal struct definitions
+    MODAL_STRUCTS=$(grep "^type.*Modal struct" "$file" 2>/dev/null || true)
+    
+    if [ -n "$MODAL_STRUCTS" ]; then
+        echo -e "${RED}❌ VIOLATION: Modal struct defined in intents package${NC}"
+        echo "   File: $file"
+        echo ""
+        echo "   Found:"
+        echo "$MODAL_STRUCTS" | sed 's/^/   /'
+        echo ""
+        echo "   Rule: Modal structs MUST NOT be in intents/ package"
+        echo ""
+        echo "   Allowed locations:"
+        echo "   - internal/cli/uikit/feedback/    (reusable modals)"
+        echo "   - internal/cli/screens/*/modals/  (feature-specific modals)"
+        echo "   - internal/cli/components/        (legacy, deprecated)"
+        echo ""
+        echo "   Required action:"
+        echo "   1. Create screens/{feature}/modals/ directory"
+        echo "   2. Move modal struct to {action}_modal.go"
+        echo "   3. Update imports in intent"
+        echo "   4. Delete original file if empty"
+        echo ""
+        VIOLATIONS=$((VIOLATIONS+1))
+    fi
+done
+
+if [ $VIOLATIONS -eq 0 ]; then
+    echo -e "${GREEN}✅ No modal structs in intents package${NC}"
+fi
+
+echo ""
+
+# ============================================
+# 25. HUH IMPORT LOCATION
+# ============================================
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "25. HUH IMPORT LOCATION"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# huh should ONLY be imported in forms/ package
+# Check intents/ for violations
+HUH_IN_INTENTS=$(grep -l "github.com/charmbracelet/huh" internal/cli/intents/*.go internal/cli/intents/**/*.go 2>/dev/null | grep -v "_test.go" || true)
+
+if [ -n "$HUH_IN_INTENTS" ]; then
+    echo -e "${RED}❌ VIOLATION: Direct huh import in intents package${NC}"
+    echo ""
+    echo "   Files with violation:"
+    echo "$HUH_IN_INTENTS" | sed 's/^/   - /'
+    echo ""
+    echo "   Rule: huh library must ONLY be imported in forms/ package"
+    echo ""
+    echo "   WRONG: import \"github.com/charmbracelet/huh\" (in intents/)"
+    echo "   RIGHT: import \"github.com/baphled/kariya/internal/cli/forms\""
+    echo ""
+    echo "   Use forms package utilities:"
+    echo "   - forms.NewInput(), forms.NewSelect(), etc."
+    echo "   - forms.IsCompleted(form), forms.IsAborted(form)"
+    echo "   - forms.NewForm(groups...)"
+    echo ""
+    VIOLATIONS=$((VIOLATIONS+1))
+fi
+
+# Check screens/ for violations (allowed in screens/*/modals/ for form-based modals)
+HUH_IN_SCREENS=$(grep -l "github.com/charmbracelet/huh" internal/cli/screens/*.go internal/cli/screens/**/*.go 2>/dev/null | grep -v "_test.go" | grep -v "/modals/" || true)
+
+if [ -n "$HUH_IN_SCREENS" ]; then
+    echo -e "${YELLOW}⚠️  WARNING: Direct huh import in screens package${NC}"
+    echo ""
+    echo "   Files:"
+    echo "$HUH_IN_SCREENS" | sed 's/^/   - /'
+    echo ""
+    echo "   Note: huh import is allowed in screens/*/modals/ for form-based modals"
+    echo "   Recommendation: Use forms/ package utilities where possible"
+    echo ""
+    WARNINGS=$((WARNINGS+1))
+fi
+
+if [ -z "$HUH_IN_INTENTS" ] && [ -z "$HUH_IN_SCREENS" ]; then
+    echo -e "${GREEN}✅ huh imports in correct locations${NC}"
+fi
+
+echo ""
+
+# ============================================
+# 26. RENDER METHODS IN HELPERS.GO
+# ============================================
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "26. RENDER METHODS IN HELPERS.GO"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Check helpers.go files in subdirectory intents for render methods
+if [ -n "$SUBDIRS" ]; then
+    for intent_dir in $SUBDIRS; do
+        HELPERS_FILE="$intent_dir/helpers.go"
+        INTENT_NAME=$(basename "$intent_dir")
+        
+        if [ -f "$HELPERS_FILE" ]; then
+            # Count render/view content methods
+            RENDER_METHODS=$(grep -E "func.*\) get.*Content|func.*\) render|func.*\) view" "$HELPERS_FILE" 2>/dev/null | wc -l)
+            
+            if [ "$RENDER_METHODS" -gt 2 ]; then
+                echo -e "${RED}❌ VIOLATION: Too many render methods in helpers.go${NC}"
+                echo "   File: $HELPERS_FILE ($RENDER_METHODS render methods)"
+                echo "   Rule: Render logic must be in screens/ package"
+                echo ""
+                echo "   Found methods:"
+                grep -nE "func.*\) get.*Content|func.*\) render|func.*\) view" "$HELPERS_FILE" 2>/dev/null | head -10 | sed 's/^/   /' || true
+                echo ""
+                echo "   Required action:"
+                echo "   1. Create screens/$INTENT_NAME/ directory"
+                echo "   2. Create screen files (list.go, detail.go, form.go)"
+                echo "   3. Move render methods to appropriate screens"
+                echo "   4. Update intent to delegate to screens"
+                echo ""
+                echo "   Naming convention:"
+                echo "   - screens/$INTENT_NAME/list.go    -> {Entity}ListScreen"
+                echo "   - screens/$INTENT_NAME/detail.go  -> {Entity}DetailScreen"
+                echo "   - screens/$INTENT_NAME/form.go    -> {Entity}FormScreen"
+                echo ""
+                VIOLATIONS=$((VIOLATIONS+1))
+            fi
+        fi
+    done
+fi
+
+if [ $VIOLATIONS -eq 0 ]; then
+    echo -e "${GREEN}✅ No excessive render methods in helpers.go${NC}"
+fi
+
+echo ""
+
+# ============================================
+# 27. SCREENS EXISTENCE FOR MULTI-STATE INTENTS
+# ============================================
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "27. SCREENS EXISTENCE FOR MULTI-STATE INTENTS"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Intents with 2+ states MUST have screens extracted
+if [ -n "$SUBDIRS" ]; then
+    for intent_dir in $SUBDIRS; do
+        INTENT_NAME=$(basename "$intent_dir")
+        CONSTANTS_FILE="$intent_dir/constants.go"
+        
+        if [ -f "$CONSTANTS_FILE" ]; then
+            # Count state constants (State... = "...")
+            STATE_COUNT=$(grep -c "State.*=.*\"" "$CONSTANTS_FILE" 2>/dev/null || echo 0)
+            
+            if [ "$STATE_COUNT" -ge 2 ]; then
+                # Multiple states - check for corresponding screens directory
+                # Try various naming conventions
+                FOUND_SCREENS=false
+                
+                # Direct match: fact_management -> screens/fact_management/
+                if [ -d "internal/cli/screens/$INTENT_NAME" ]; then
+                    FOUND_SCREENS=true
+                fi
+                
+                # Without _management suffix: burst_management -> screens/burst/
+                SHORT_NAME=$(echo "$INTENT_NAME" | sed 's/_management$//' | sed 's/_intent$//')
+                if [ -d "internal/cli/screens/$SHORT_NAME" ]; then
+                    FOUND_SCREENS=true
+                fi
+                
+                # browse_timeline -> screens/timeline/
+                BROWSE_NAME=$(echo "$INTENT_NAME" | sed 's/^browse_//')
+                if [ -d "internal/cli/screens/$BROWSE_NAME" ]; then
+                    FOUND_SCREENS=true
+                fi
+                
+                # manage_skills -> screens/skills/
+                MANAGE_NAME=$(echo "$INTENT_NAME" | sed 's/^manage_//')
+                if [ -d "internal/cli/screens/$MANAGE_NAME" ]; then
+                    FOUND_SCREENS=true
+                fi
+                
+                if [ "$FOUND_SCREENS" = false ]; then
+                    echo -e "${RED}❌ VIOLATION: Intent has $STATE_COUNT states but no screens directory${NC}"
+                    echo "   Intent: $INTENT_NAME"
+                    echo "   States: $STATE_COUNT"
+                    echo ""
+                    echo "   Rule: Intents with 2+ states MUST have extracted screens"
+                    echo ""
+                    echo "   Required action:"
+                    echo "   1. Create internal/cli/screens/$INTENT_NAME/"
+                    echo "   2. Create screen files for each state:"
+                    grep "State.*=.*\"" "$CONSTANTS_FILE" 2>/dev/null | head -10 | while read -r line; do
+                        STATE=$(echo "$line" | grep -oP 'State\w+' | head -1)
+                        echo "      - $STATE -> corresponding screen"
+                    done
+                    echo "   3. Extract render methods from helpers.go to screens"
+                    echo "   4. Update intent to orchestrate screens"
+                    echo ""
+                    VIOLATIONS=$((VIOLATIONS+1))
+                fi
+            fi
+        fi
+    done
+fi
+
+if [ $VIOLATIONS -eq 0 ]; then
+    echo -e "${GREEN}✅ All multi-state intents have screens${NC}"
+fi
+
+echo ""
+
+# ============================================
+# 28. MODAL AND SCREEN LOCATION VALIDATION
+# ============================================
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "28. MODAL AND SCREEN LOCATION VALIDATION"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Check for Screen structs in wrong locations
+SCREEN_WRONG_LOCATIONS=$(find internal/cli -name "*.go" -not -path "*/screens/*" -not -name "*_test.go" -exec grep -l "^type.*Screen struct" {} \; 2>/dev/null || true)
+
+if [ -n "$SCREEN_WRONG_LOCATIONS" ]; then
+    echo -e "${RED}❌ VIOLATION: Screen struct defined outside screens/ package${NC}"
+    echo ""
+    echo "   Files with violation:"
+    echo "$SCREEN_WRONG_LOCATIONS" | sed 's/^/   - /'
+    echo ""
+    echo "   Rule: Screen structs MUST be in internal/cli/screens/*/"
+    echo ""
+    echo "   Naming convention:"
+    echo "   - File: screens/{feature}/{type}.go (e.g., screens/facts/list.go)"
+    echo "   - Struct: {Entity}{Type}Screen (e.g., FactListScreen)"
+    echo "   - Constructor: New{Entity}{Type}Screen()"
+    echo ""
+    VIOLATIONS=$((VIOLATIONS+1))
+fi
+
+# Check for Modal structs in wrong locations (excluding allowed locations)
+MODAL_WRONG_LOCATIONS=$(find internal/cli -name "*.go" \
+    -not -path "*/uikit/feedback/*" \
+    -not -path "*/screens/*/modals/*" \
+    -not -path "*/components/*" \
+    -not -name "*_test.go" \
+    -exec grep -l "^type.*Modal struct" {} \; 2>/dev/null || true)
+
+if [ -n "$MODAL_WRONG_LOCATIONS" ]; then
+    echo -e "${RED}❌ VIOLATION: Modal struct defined in wrong location${NC}"
+    echo ""
+    echo "   Files with violation:"
+    echo "$MODAL_WRONG_LOCATIONS" | sed 's/^/   - /'
+    echo ""
+    echo "   Rule: Modal structs must be in allowed locations only"
+    echo ""
+    echo "   Allowed locations:"
+    echo "   - internal/cli/uikit/feedback/     (reusable modals)"
+    echo "   - internal/cli/screens/*/modals/   (feature-specific modals)"
+    echo "   - internal/cli/components/         (legacy, deprecated)"
+    echo ""
+    echo "   Naming convention:"
+    echo "   - File: {action}_modal.go (e.g., edit_modal.go)"
+    echo "   - Struct: {Action}Modal (e.g., EditModal)"
+    echo "   - Constructor: New{Action}Modal()"
+    echo ""
+    VIOLATIONS=$((VIOLATIONS+1))
+fi
+
+if [ -z "$SCREEN_WRONG_LOCATIONS" ] && [ -z "$MODAL_WRONG_LOCATIONS" ]; then
+    echo -e "${GREEN}✅ All screens and modals in correct locations${NC}"
+fi
+
+echo ""
+
+# ============================================
+# 29. NAMING CONVENTION ENFORCEMENT
+# ============================================
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "29. NAMING CONVENTION ENFORCEMENT"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Check screen struct naming (must end with "Screen")
+# Exclude: base/, contract.go, helpers.go, modals/, *_modal.go
+SCREEN_FILES=$(find internal/cli/screens -name "*.go" \
+    -not -name "*_test.go" \
+    -not -path "*/modals/*" \
+    -not -path "*/base/*" \
+    -not -name "helpers.go" \
+    -not -name "contract.go" \
+    -not -name "*_modal.go" \
+    2>/dev/null || true)
+
+for screen_file in $SCREEN_FILES; do
+    # Find struct definitions
+    STRUCTS=$(grep "^type.*struct" "$screen_file" 2>/dev/null | grep -v "//" || true)
+    
+    if [ -n "$STRUCTS" ]; then
+        while IFS= read -r struct_line; do
+            STRUCT_NAME=$(echo "$struct_line" | awk '{print $2}')
+            
+            # Skip helper/data types (common suffixes that are NOT screens)
+            if [[ "$STRUCT_NAME" =~ ^Base || \
+                  "$STRUCT_NAME" =~ Config$ || \
+                  "$STRUCT_NAME" =~ Options$ || \
+                  "$STRUCT_NAME" =~ Option$ || \
+                  "$STRUCT_NAME" =~ Data$ || \
+                  "$STRUCT_NAME" =~ Result$ || \
+                  "$STRUCT_NAME" =~ Stats$ || \
+                  "$STRUCT_NAME" =~ Filters$ || \
+                  "$STRUCT_NAME" =~ State$ || \
+                  "$STRUCT_NAME" =~ Context$ || \
+                  "$STRUCT_NAME" =~ Params$ || \
+                  "$STRUCT_NAME" =~ Info$ || \
+                  "$STRUCT_NAME" =~ Item$ || \
+                  "$STRUCT_NAME" =~ Msg$ || \
+                  "$STRUCT_NAME" =~ Modal$ ]]; then
+                continue
+            fi
+            
+            # Check if struct name ends with "Screen"
+            if [[ ! "$STRUCT_NAME" =~ Screen$ ]]; then
+                echo -e "${RED}❌ VIOLATION: Screen struct missing 'Screen' suffix${NC}"
+                echo "   File: $screen_file"
+                echo "   Struct: $STRUCT_NAME"
+                echo "   Rule: Screen structs must end with 'Screen'"
+                echo ""
+                echo "   Required: ${STRUCT_NAME}Screen"
+                echo ""
+                VIOLATIONS=$((VIOLATIONS+1))
+            fi
+        done <<< "$STRUCTS"
+    fi
+done
+
+# Check modal file naming and struct naming
+# Only check *_modal.go files in modals/ directories and uikit/feedback/
+MODAL_FILES=$(find internal/cli/screens -path "*/modals/*" -name "*_modal.go" -not -name "*_test.go" 2>/dev/null || true)
+FEEDBACK_MODAL_FILES=$(find internal/cli/uikit/feedback -name "*_modal.go" -not -name "*_test.go" 2>/dev/null || true)
+
+# Check for multiple MODAL structs in modal files (one modal per file rule)
+# Data structs (Config, Data, Filters, etc.) are allowed alongside the modal
+for modal_file in $MODAL_FILES $FEEDBACK_MODAL_FILES; do
+    if [ -n "$modal_file" ] && [ -f "$modal_file" ]; then
+        FILENAME=$(basename "$modal_file")
+        
+        # Skip helpers.go
+        if [[ "$FILENAME" == "helpers.go" ]]; then
+            continue
+        fi
+        
+        # Count only structs ending with "Modal" (the actual modal structs)
+        MODAL_STRUCT_COUNT=$(grep -c "^type.*Modal struct" "$modal_file" 2>/dev/null || echo 0)
+        
+        if [ "$MODAL_STRUCT_COUNT" -gt 1 ]; then
+            echo -e "${RED}❌ VIOLATION: Multiple modal structs in single file${NC}"
+            echo "   File: $modal_file ($MODAL_STRUCT_COUNT modal structs)"
+            echo "   Rule: One modal struct per file (data structs are allowed)"
+            echo ""
+            echo "   Found modal structs:"
+            grep "^type.*Modal struct" "$modal_file" 2>/dev/null | sed 's/^/   /' || true
+            echo ""
+            echo "   Required action: Split modal structs into separate files"
+            echo "   Note: Helper structs (Config, Data, Filters) can stay"
+            echo ""
+            VIOLATIONS=$((VIOLATIONS+1))
+        fi
+    fi
+done
+
+# Check screen package naming (must use underscore, not hyphen)
+SCREEN_DIRS=$(find internal/cli/screens -mindepth 1 -maxdepth 1 -type d 2>/dev/null || true)
+
+for screen_dir in $SCREEN_DIRS; do
+    PKG_NAME=$(basename "$screen_dir")
+    
+    if [[ "$PKG_NAME" =~ - ]]; then
+        echo -e "${RED}❌ VIOLATION: Screen package uses hyphen${NC}"
+        echo "   Package: $screen_dir"
+        echo "   Rule: Use underscore for package names (e.g., fact_management/)"
+        echo ""
+        echo "   Found: $PKG_NAME"
+        echo "   Required: $(echo "$PKG_NAME" | tr '-' '_')"
+        echo ""
+        VIOLATIONS=$((VIOLATIONS+1))
+    fi
+done
+
+if [ $VIOLATIONS -eq 0 ]; then
+    echo -e "${GREEN}✅ Naming conventions followed${NC}"
+fi
+
+echo ""
+
+# ============================================
 # SUMMARY
 # ============================================
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "📊 SUMMARY"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
-echo "Total checks run: 23"
+echo "Total checks run: 29"
 echo "Violations: $VIOLATIONS"
 echo "Warnings: $WARNINGS"
 echo ""


### PR DESCRIPTION
## Summary

- Add 6 new blocking architecture checks (#24-29) to enforce screen and modal extraction from intents
- Prevent the issue where `fact_management` refactoring missed extracting screens and modals
- Add naming convention documentation and migration task for existing violations

## New Checks

| Check | Name | What It Catches |
|-------|------|-----------------|
| #24 | Modal in intents/ | Any `type *Modal struct` in intents package |
| #25 | huh import location | `huh` import outside `forms/` package |
| #26 | Render in helpers.go | >2 render methods in helpers.go |
| #27 | Screens existence | 2+ states without screens/ directory |
| #28 | Modal/Screen location | Structs in wrong packages |
| #29 | Naming conventions | Screen/Modal suffixes, underscore packages |

## Files Added

- `docs/conventions/SCREEN_NAMING.md` - Screen naming rules and examples
- `docs/conventions/MODAL_NAMING.md` - Modal naming rules and examples  
- `docs/tasks/MIGRATE_INTENTS_MODALS.md` - Migration task for `intents/modals.go`

## Files Modified

- `scripts/check-intent-architecture.sh` - Added 6 new checks
- `AGENTS.md` - Added checks #24-29, naming conventions section

## Why This Matters

During the `fact_management` refactoring, we correctly created the subdirectory structure but **completely missed** extracting:
- Screens to `screens/fact_management/`
- Modals from `intents/modals.go` to proper locations

These new checks will catch this pattern in the future by:
1. Detecting modal structs anywhere in `intents/` package
2. Detecting direct `huh` imports outside `forms/`
3. Detecting >2 render methods in `helpers.go`
4. Requiring screens directory for intents with 2+ states
5. Validating modal/screen struct locations
6. Enforcing naming conventions

## Testing

```bash
# Run checks (will show pre-existing violations)
make check-intent-architecture

# Violations now correctly detected:
# - intents/modals.go with EditBurstModal, EditFactModal
# - intents/modals.go with direct huh import
# - fact_management/helpers.go with 5 render methods
# - fact_management with 6 states but no screens/
```