### PR TITLE
fix(service): address PR #126 review feedback for burst confirmation

### DIFF
--- a/internal/cli/importer/service_test.go
+++ b/internal/cli/importer/service_test.go
@@ -155,24 +155,29 @@ Optimized cloud infrastructure performance,2024-01-25,Technical,technical,CloudM
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.SuccessCount).To(Equal(3))
 
-			// Get all saved bursts.
+			// Bursts must have been detected from these clustered events.
 			allBursts, err := burstRepo.List(ctx, careerrepo.BurstListFilters{})
 			Expect(err).NotTo(HaveOccurred())
+			Expect(allBursts).NotTo(BeEmpty(),
+				"clustered events with same project/company should produce at least one burst")
 
-			if len(allBursts) > 0 {
-				// If bursts were detected, verify facts are linked.
-				allFacts, err := factRepo.List(ctx, careerrepo.FactListFilters{})
-				Expect(err).NotTo(HaveOccurred())
-
-				// At least some facts should have SourceBurstID set.
-				factsWithBurstID := 0
-				for _, fact := range allFacts {
-					if fact.SourceBurstID != "" {
-						factsWithBurstID++
-					}
+			// Build set of event IDs belonging to bursts.
+			burstEventIDs := make(map[string]bool)
+			for _, burst := range allBursts {
+				for _, eid := range burst.EventIDs {
+					burstEventIDs[eid] = true
 				}
-				Expect(factsWithBurstID).To(BeNumerically(">", 0),
-					"facts belonging to burst events should have SourceBurstID set")
+			}
+
+			// Every fact whose event belongs to a burst must have SourceBurstID set.
+			allFacts, err := factRepo.List(ctx, careerrepo.FactListFilters{})
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, fact := range allFacts {
+				if burstEventIDs[fact.SourceEventID] {
+					Expect(fact.SourceBurstID).NotTo(BeEmpty(),
+						"fact for burst event %s should have SourceBurstID set", fact.SourceEventID)
+				}
 			}
 		})
 

--- a/internal/cli/intents/burst_management/helpers.go
+++ b/internal/cli/intents/burst_management/helpers.go
@@ -264,20 +264,16 @@ func (i *Intent) confirmBurst() tea.Cmd {
 		return nil
 	}
 
-	// Save to repository first (if available) BEFORE modifying in-memory state.
-	if i.context.BurstRepository != nil {
+	// Delegate to the service which handles Confirmed, ConfirmedAt, UpdatedAt,
+	// and rolls back correctly on failure.
+	if i.context.Service != nil {
 		ctx := i.getContext()
-		i.selectedBurst.Confirmed = true
-		err := i.context.BurstRepository.Update(ctx, i.selectedBurst)
-		if err != nil {
-			// Rollback in-memory change on failure.
-			i.selectedBurst.Confirmed = false
+		if err := i.context.Service.ConfirmBurst(ctx, i.selectedBurst); err != nil {
 			i.confirmError = err
 			i.errorModal = feedback.NewErrorModal("Confirmation Failed", err.Error())
 			return nil
 		}
 	} else {
-		// No repository - just update in memory.
 		i.selectedBurst.Confirmed = true
 	}
 

--- a/internal/cli/intents/burst_management/helpers.go
+++ b/internal/cli/intents/burst_management/helpers.go
@@ -4,6 +4,7 @@ package burst_management
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/baphled/kariya/internal/cli/behaviors"
 	"github.com/baphled/kariya/internal/cli/intents"
@@ -274,7 +275,10 @@ func (i *Intent) confirmBurst() tea.Cmd {
 			return nil
 		}
 	} else {
+		now := time.Now()
 		i.selectedBurst.Confirmed = true
+		i.selectedBurst.ConfirmedAt = &now
+		i.selectedBurst.UpdatedAt = now
 	}
 
 	// Trigger fact extraction for the confirmed burst.

--- a/internal/cli/intents/burst_management/intent_test.go
+++ b/internal/cli/intents/burst_management/intent_test.go
@@ -3,6 +3,7 @@ package burst_management_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -1917,8 +1918,8 @@ var _ = Describe("Intent Methods", func() {
 		})
 
 		It("should handle confirm error gracefully", func() {
-			// Remove burst from repo to simulate update error.
-			_ = repo.Delete(ctx.Context, burst.ID)
+			// Configure service to fail on confirm.
+			mockService.SetConfirmError(fmt.Errorf("database unavailable"))
 
 			// Navigate to detail and confirm.
 			navResult := &screens.NavigateResult{ResultData: burst}

--- a/internal/cli/intents/burst_management/interfaces.go
+++ b/internal/cli/intents/burst_management/interfaces.go
@@ -18,6 +18,9 @@ type BurstService interface {
 	GetEventByID(ctx context.Context, eventID string) (*career.CareerEvent, error)
 	ListEvents(ctx context.Context, filters careerrepo.EventListFilters) ([]*career.CareerEvent, error)
 
+	// Burst confirmation.
+	ConfirmBurst(ctx context.Context, burst *career.Burst) error
+
 	// Fact operations.
 	GetFactsBySourceBurstID(ctx context.Context, burstID string) ([]*career.Fact, error)
 	ExtractFactsFromBurst(ctx context.Context, burst *career.Burst) ([]career.Fact, error)

--- a/internal/service/career/burst_service_test.go
+++ b/internal/service/career/burst_service_test.go
@@ -3,6 +3,7 @@ package career
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/baphled/kariya/internal/domain/career"
@@ -119,6 +120,32 @@ var _ = Describe("Career Service - Burst Methods", func() {
 			burst := fixtures.Burst("", "1", "2")
 			err := service.ConfirmBurst(ctx, burst)
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("should restore original state on repository update failure", func() {
+			// Create an already-confirmed burst.
+			burst := fixtures.Burst("burst-rollback", "1", "2")
+			confirmedAt := time.Now().Add(-24 * time.Hour)
+			burst.Confirmed = true
+			burst.ConfirmedAt = &confirmedAt
+			err := burstRepo.Create(ctx, burst)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Capture state after Create (which sets its own UpdatedAt).
+			origUpdatedAt := burst.UpdatedAt
+
+			// Use a failing repo to trigger rollback.
+			failRepo := &failingBurstRepo{inner: burstRepo}
+			service.SetBurstRepository(failRepo)
+
+			err = service.ConfirmBurst(ctx, burst)
+			Expect(err).To(HaveOccurred())
+
+			// Original state must be fully preserved after rollback.
+			Expect(burst.Confirmed).To(BeTrue(), "rollback should restore original Confirmed")
+			Expect(burst.ConfirmedAt).To(Equal(&confirmedAt), "rollback should restore original ConfirmedAt")
+			Expect(burst.UpdatedAt).To(BeTemporally("~", origUpdatedAt, time.Millisecond),
+				"rollback should restore original UpdatedAt")
 		})
 	})
 
@@ -279,3 +306,32 @@ var _ = Describe("Career Service - Burst Methods", func() {
 		})
 	})
 })
+
+// failingBurstRepo wraps a real repository but forces Update to fail.
+type failingBurstRepo struct {
+	inner careerrepo.BurstRepository
+}
+
+func (f *failingBurstRepo) Create(ctx context.Context, burst *career.Burst) error {
+	return f.inner.Create(ctx, burst)
+}
+
+func (f *failingBurstRepo) GetByID(ctx context.Context, id string) (*career.Burst, error) {
+	return f.inner.GetByID(ctx, id)
+}
+
+func (f *failingBurstRepo) Update(_ context.Context, _ *career.Burst) error {
+	return errors.New("forced update failure")
+}
+
+func (f *failingBurstRepo) Delete(ctx context.Context, id string) error {
+	return f.inner.Delete(ctx, id)
+}
+
+func (f *failingBurstRepo) List(ctx context.Context, filters careerrepo.BurstListFilters) ([]*career.Burst, error) {
+	return f.inner.List(ctx, filters)
+}
+
+func (f *failingBurstRepo) Count(ctx context.Context, filters careerrepo.BurstListFilters) (int, error) {
+	return f.inner.Count(ctx, filters)
+}

--- a/internal/service/career/service.go
+++ b/internal/service/career/service.go
@@ -341,6 +341,11 @@ func (s *Service) ConfirmBurst(ctx context.Context, burst *domain.Burst) error {
 		return err
 	}
 
+	// Capture original state for rollback on failure.
+	origConfirmed := burst.Confirmed
+	origConfirmedAt := burst.ConfirmedAt
+	origUpdatedAt := burst.UpdatedAt
+
 	now := time.Now()
 	burst.Confirmed = true
 	burst.ConfirmedAt = &now
@@ -349,8 +354,9 @@ func (s *Service) ConfirmBurst(ctx context.Context, burst *domain.Burst) error {
 	if s.burstRepo != nil {
 		if err := s.burstRepo.Update(ctx, burst); err != nil {
 			// Rollback in-memory changes on failure.
-			burst.Confirmed = false
-			burst.ConfirmedAt = nil
+			burst.Confirmed = origConfirmed
+			burst.ConfirmedAt = origConfirmedAt
+			burst.UpdatedAt = origUpdatedAt
 			s.logger.WithFields(map[string]string{
 				"burst_id": burst.ID,
 				"error":    err.Error(),

--- a/internal/testutil/e2e/burst_management_intent_e2e_test.go
+++ b/internal/testutil/e2e/burst_management_intent_e2e_test.go
@@ -2687,10 +2687,11 @@ var _ = Describe("Burst Suggestion Persistence Tests", func() {
 // These test what happens when database operations fail during user workflows.
 var _ = Describe("User Journey: Database Failure Handling", func() {
 	var (
-		intent   *burst_management.Intent
-		ctx      *burst_management.IntentContext
-		mockRepo *mocks.BurstRepositoryMock
-		burst    *career.Burst
+		intent      *burst_management.Intent
+		ctx         *burst_management.IntentContext
+		mockRepo    *mocks.BurstRepositoryMock
+		mockService *mocks.BurstServiceMock
+		burst       *career.Burst
 	)
 
 	BeforeEach(func() {
@@ -2703,10 +2704,12 @@ var _ = Describe("User Journey: Database Failure Handling", func() {
 		}
 
 		mockRepo = mocks.NewBurstRepositoryMock().AddBurst(burst)
+		mockService = mocks.NewBurstServiceMock()
 
 		ctx = &burst_management.IntentContext{
 			Bursts:          []*career.Burst{burst},
 			BurstRepository: mockRepo,
+			Service:         mockService,
 		}
 		ctx.Validate()
 
@@ -2768,8 +2771,8 @@ var _ = Describe("User Journey: Database Failure Handling", func() {
 
 	Describe("When I confirm a burst but the database fails", func() {
 		It("should show an error and leave the burst unconfirmed", func() {
-			// Given: A database that will fail on update.
-			mockRepo.SetUpdateError(fmt.Errorf("write permission denied"))
+			// Given: A service that will fail on confirm.
+			mockService.SetConfirmError(fmt.Errorf("write permission denied"))
 
 			// And: I'm viewing an unconfirmed burst.
 			result := &screens.NavigateResult{ResultData: burst}

--- a/internal/testutil/mocks/burst_service_mock.go
+++ b/internal/testutil/mocks/burst_service_mock.go
@@ -22,6 +22,8 @@ type BurstServiceMock struct {
 	listEventsError  error
 	extractCallCount int
 	saveFactError    error
+	confirmError     error
+	confirmCallCount int
 }
 
 // NewBurstServiceMock creates a new configurable BurstService mock.
@@ -74,6 +76,17 @@ func (m *BurstServiceMock) SetSaveFactError(err error) *BurstServiceMock {
 	return m
 }
 
+// SetConfirmError configures an error to be returned by ConfirmBurst.
+func (m *BurstServiceMock) SetConfirmError(err error) *BurstServiceMock {
+	m.confirmError = err
+	return m
+}
+
+// GetConfirmCallCount returns how many times ConfirmBurst was called.
+func (m *BurstServiceMock) GetConfirmCallCount() int {
+	return m.confirmCallCount
+}
+
 // SetFactsForBurst configures facts to be returned for a specific burst ID.
 func (m *BurstServiceMock) SetFactsForBurst(burstID string, facts []*career.Fact) *BurstServiceMock {
 	m.facts[burstID] = facts
@@ -88,6 +101,18 @@ func (m *BurstServiceMock) GetExtractCallCount() int {
 // GetSavedFacts returns all facts that were saved via SaveFact.
 func (m *BurstServiceMock) GetSavedFacts() []*career.Fact {
 	return m.savedFacts
+}
+
+// ConfirmBurst implements BurstService.
+func (m *BurstServiceMock) ConfirmBurst(_ context.Context, burst *career.Burst) error {
+	m.confirmCallCount++
+	if m.confirmError != nil {
+		return m.confirmError
+	}
+	if burst != nil {
+		burst.Confirmed = true
+	}
+	return nil
 }
 
 // GetFactsBySourceBurstID implements BurstService.

--- a/internal/testutil/mocks/burst_service_mock.go
+++ b/internal/testutil/mocks/burst_service_mock.go
@@ -4,6 +4,7 @@ package mocks
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/baphled/kariya/internal/domain/career"
 	careerrepo "github.com/baphled/kariya/internal/repository/career"
@@ -104,13 +105,17 @@ func (m *BurstServiceMock) GetSavedFacts() []*career.Fact {
 }
 
 // ConfirmBurst implements BurstService.
+// Mirrors the real service: sets Confirmed, ConfirmedAt, and UpdatedAt.
 func (m *BurstServiceMock) ConfirmBurst(_ context.Context, burst *career.Burst) error {
 	m.confirmCallCount++
 	if m.confirmError != nil {
 		return m.confirmError
 	}
 	if burst != nil {
+		now := time.Now()
 		burst.Confirmed = true
+		burst.ConfirmedAt = &now
+		burst.UpdatedAt = now
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Addresses Copilot review comments from PR #126 (accidentally merged before review feedback was resolved).

- **Strengthen importer test**: Replace `if len(allBursts) > 0` guard with `Expect(allBursts).NotTo(BeEmpty())` assertion, and verify every fact for burst events has `SourceBurstID` set. The test now fails if burst detection doesn't produce results, instead of silently passing.
- **Fix ConfirmBurst rollback**: Capture original `Confirmed`, `ConfirmedAt`, and `UpdatedAt` before mutation, restoring all three on repository update failure. Previously hard-coded `false`/`nil` which would incorrectly unconfirm an already-confirmed burst.
- **Delegate confirmBurst to service**: Add `ConfirmBurst` to `BurstService` interface. Intent's `confirmBurst()` now calls `Service.ConfirmBurst()` which properly handles `ConfirmedAt`/`UpdatedAt` timestamps and rollback, instead of directly mutating state and calling the repository.

## Review Comments Addressed

| Comment | File | Fix |
|---------|------|-----|
| Test can pass without asserting new behavior | `importer/service_test.go` | Assert bursts exist, verify all burst-event facts have SourceBurstID |
| Rollback doesn't preserve original state | `service/career/service.go` | Capture and restore all three fields on failure |
| confirmBurst doesn't set ConfirmedAt, mutates before Update | `burst_management/helpers.go` | Delegate to Service.ConfirmBurst |

## Files Changed

| File | Change |
|------|--------|
| `internal/cli/importer/service_test.go` | Strengthen burst linking test |
| `internal/service/career/service.go` | Full state rollback in ConfirmBurst |
| `internal/service/career/burst_service_test.go` | Test rollback preserves original state |
| `internal/cli/intents/burst_management/interfaces.go` | Add ConfirmBurst to BurstService |
| `internal/cli/intents/burst_management/helpers.go` | Delegate to service |
| `internal/cli/intents/burst_management/intent_test.go` | Update confirm error test |
| `internal/testutil/e2e/burst_management_intent_e2e_test.go` | Update E2E confirm failure test |
| `internal/testutil/mocks/burst_service_mock.go` | Add ConfirmBurst mock |