### PR TITLE
fix(cv): skip project-only events in tenure detection (BUG-012)

### DIFF
--- a/bugs/BUG-012-tenure-detection-project-events.md
+++ b/bugs/BUG-012-tenure-detection-project-events.md
@@ -1,0 +1,74 @@
+# BUG-012: Tenure detection treats project-only events as intervening company events
+
+## Summary
+
+`hasInterveningCompanyEvents()` assigns `DefaultCompanyName` ("Other") to events
+with empty Company fields (project-only entries like n-vyro.io, QuikCV, KaRiya).
+These are then treated as employment at a different company, causing false tenure
+splits within a single employment stint when there is a month gap in entries.
+
+## Steps to Reproduce
+
+1. Import career events where a company has a month gap (e.g., Mindful Chef has
+   entries for Feb 2024 and Apr 2024 but not Mar 2024)
+2. Ensure project-only entries exist during that gap (e.g., n-vyro.io at Mar 2024)
+3. Generate a CV via `kariya` TUI
+4. Observe the company appears as multiple separate tenures
+
+## Expected Behavior
+
+Mindful Chef second stint should appear as one tenure: Jul 2023 - Apr 2024.
+
+## Actual Behavior
+
+Mindful Chef second stint is split into two tenures:
+
+- Mindful Chef: Jul 2023 - Feb 2024
+- Mindful Chef: Apr 2024
+
+The n-vyro.io entry at Mar 2024 (Company="", Project="n-vyro.io") is assigned
+`DefaultCompanyName = "Other"` and counted as an intervening event between the
+Feb 2024 and Apr 2024 Mindful Chef entries.
+
+## Root Cause
+
+**File**: `internal/service/career/cv/data_processing_service.go:254-258`
+
+```go
+eventCompany := event.Company
+if eventCompany == "" {
+    eventCompany = constants.DefaultCompanyName  // "Other"
+}
+```
+
+Project-only events (personal/side projects with no Company) should not influence
+employment tenure detection. They run concurrently with employment and are not
+"intervening" work at another employer.
+
+## Fix Plan
+
+In `hasInterveningCompanyEvents`, skip events with empty Company instead of
+assigning a default:
+
+```go
+if event.Company == "" {
+    continue  // Project-only events don't affect employment tenures
+}
+```
+
+## Regression Tests
+
+- `hasInterveningCompanyEvents` returns false when only project-only events exist between dates
+- `hasInterveningCompanyEvents` still returns true when real company events intervene
+- Mindful Chef with month gap and concurrent n-vyro.io entries produces 2 tenures (not 3)
+- Existing BUG-009 tenure detection still correctly splits genuine separate stints
+
+## Related
+
+- BUG-009: CV tenure detection (the feature that introduced `hasInterveningCompanyEvents`)
+- BUG-013: Bullet deduplication merges across companies
+- BUG-014: Date calculation ignores primary company
+
+## Severity
+
+- [x] High - CV displays incorrect employment history

--- a/internal/service/career/cv/data_processing_service.go
+++ b/internal/service/career/cv/data_processing_service.go
@@ -252,13 +252,14 @@ func hasInterveningCompanyEvents(
 	allEventsSorted []*career.CareerEvent,
 ) bool {
 	for _, event := range allEventsSorted {
-		eventCompany := event.Company
-		if eventCompany == "" {
-			eventCompany = constants.DefaultCompanyName
+		// BUG-012: Skip project-only events (empty Company) — they run
+		// concurrently with employment and are not intervening work.
+		if event.Company == "" {
+			continue
 		}
 
 		// Skip events at the same company.
-		if eventCompany == currentCompany {
+		if event.Company == currentCompany {
 			continue
 		}
 

--- a/internal/service/career/cv/data_processing_service_test.go
+++ b/internal/service/career/cv/data_processing_service_test.go
@@ -652,4 +652,138 @@ var _ = Describe("DataProcessingService", func() {
 			})
 		})
 	})
+
+	// BUG-012: Project-only events should not split tenures
+	Describe("hasInterveningCompanyEvents", func() {
+		Context("BUG-012: project-only events (empty Company)", func() {
+			It("should return false when only project-only events exist between dates", func() {
+				// Project-only event (Company="") between two dates should NOT count
+				// as an intervening company event.
+				projectEvent := fixtures.EventWith("p1", "n-vyro.io work", "", "n-vyro.io")
+				projectEvent.Date = time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
+
+				allEvents := []*career.CareerEvent{projectEvent}
+				sort.Slice(allEvents, func(i, j int) bool {
+					return allEvents[i].Date.Before(allEvents[j].Date)
+				})
+
+				startDate := time.Date(2024, 2, 15, 0, 0, 0, 0, time.UTC)
+				endDate := time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC)
+
+				result := hasInterveningCompanyEvents(
+					startDate,
+					endDate,
+					"Mindful Chef",
+					allEvents,
+				)
+
+				Expect(result).To(BeFalse())
+			})
+
+			It("should still return true when real company events intervene", func() {
+				realCompanyEvent := fixtures.EventWith("c1", "Work at Other Corp", "Other Corp", "")
+				realCompanyEvent.Date = time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
+
+				allEvents := []*career.CareerEvent{realCompanyEvent}
+				sort.Slice(allEvents, func(i, j int) bool {
+					return allEvents[i].Date.Before(allEvents[j].Date)
+				})
+
+				startDate := time.Date(2024, 2, 15, 0, 0, 0, 0, time.UTC)
+				endDate := time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC)
+
+				result := hasInterveningCompanyEvents(
+					startDate,
+					endDate,
+					"Mindful Chef",
+					allEvents,
+				)
+
+				Expect(result).To(BeTrue())
+			})
+
+			It("should return false when mix of project-only and same-company events exist", func() {
+				projectEvent := fixtures.EventWith("p1", "n-vyro.io work", "", "n-vyro.io")
+				projectEvent.Date = time.Date(2024, 3, 10, 0, 0, 0, 0, time.UTC)
+
+				sameCompanyEvent := fixtures.EventWith("mc1", "Mindful Chef work", "Mindful Chef", "")
+				sameCompanyEvent.Date = time.Date(2024, 3, 20, 0, 0, 0, 0, time.UTC)
+
+				allEvents := []*career.CareerEvent{projectEvent, sameCompanyEvent}
+				sort.Slice(allEvents, func(i, j int) bool {
+					return allEvents[i].Date.Before(allEvents[j].Date)
+				})
+
+				startDate := time.Date(2024, 2, 15, 0, 0, 0, 0, time.UTC)
+				endDate := time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC)
+
+				result := hasInterveningCompanyEvents(
+					startDate,
+					endDate,
+					"Mindful Chef",
+					allEvents,
+				)
+
+				Expect(result).To(BeFalse())
+			})
+		})
+	})
+
+	// BUG-012: Integration-level tenure detection with project-only events
+	Describe("GroupEventsByCompany with project-only events", func() {
+		It("BUG-012: should not split tenure when only project-only events fill the gap", func() {
+			// Mindful Chef: Feb 2024 and Apr 2024 with n-vyro.io (project-only) at Mar 2024
+			// Should produce ONE Mindful Chef tenure, not two.
+			mcEvent1 := fixtures.EventWith("mc1", "Work at Mindful Chef", "Mindful Chef", "")
+			mcEvent1.Date = time.Date(2024, 2, 15, 0, 0, 0, 0, time.UTC)
+
+			mcEvent2 := fixtures.EventWith("mc2", "More at Mindful Chef", "Mindful Chef", "")
+			mcEvent2.Date = time.Date(2024, 4, 15, 0, 0, 0, 0, time.UTC)
+
+			// Project-only event (no company, just a project)
+			projectEvent := fixtures.EventWith("p1", "n-vyro.io development", "", "n-vyro.io")
+			projectEvent.Date = time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
+
+			events := []*career.CareerEvent{mcEvent1, projectEvent, mcEvent2}
+
+			result, err := dps.GroupEventsByCompany(svc, events)
+			Expect(err).NotTo(HaveOccurred())
+
+			mcCount := 0
+			for _, group := range result {
+				if group.Company == "Mindful Chef" {
+					mcCount++
+				}
+			}
+
+			// Mindful Chef should appear as ONE tenure, not split into two.
+			Expect(mcCount).To(Equal(1), "Mindful Chef should be a single tenure, not split by project-only events")
+		})
+
+		It("BUG-012: should still split tenure when real company events intervene", func() {
+			// Ensure the existing BUG-009 behavior is preserved:
+			// Company A -> Company B -> Company A should still produce two tenures for A.
+			eventA1 := fixtures.EventWith("a1", "First at A", "Company A", "")
+			eventA1.Date = time.Date(2022, 3, 15, 0, 0, 0, 0, time.UTC)
+
+			eventB := fixtures.EventWith("b1", "Work at B", "Company B", "")
+			eventB.Date = time.Date(2022, 8, 15, 0, 0, 0, 0, time.UTC)
+
+			eventA2 := fixtures.EventWith("a2", "Back at A", "Company A", "")
+			eventA2.Date = time.Date(2023, 7, 15, 0, 0, 0, 0, time.UTC)
+
+			events := []*career.CareerEvent{eventA1, eventB, eventA2}
+
+			result, err := dps.GroupEventsByCompany(svc, events)
+			Expect(err).NotTo(HaveOccurred())
+
+			companyACount := 0
+			for key := range result {
+				if key == "Company A" || strings.HasPrefix(key, "Company A"+constants.TenureSeparator) {
+					companyACount++
+				}
+			}
+			Expect(companyACount).To(Equal(2), "Real company events should still split tenures")
+		})
+	})
 })


### PR DESCRIPTION
## Summary

- **BUG-012**: `hasInterveningCompanyEvents()` assigned `DefaultCompanyName` ("Other") to events with empty `Company` fields, causing project-only entries (e.g., n-vyro.io) to be treated as intervening employment and falsely splitting tenures
- Fix skips events with empty `Company` instead of assigning a default, since project-only events run concurrently with employment
- Added 5 regression tests (3 unit-level for `hasInterveningCompanyEvents`, 2 integration-level for `GroupEventsByCompany`)

## Root Cause

In `data_processing_service.go:254-258`:

```go
// Before (buggy)
eventCompany := event.Company
if eventCompany == "" {
    eventCompany = constants.DefaultCompanyName // "Other"
}
```

Project-only events (Company="", Project="n-vyro.io") were assigned "Other" and counted as intervening work between two dates at the same company, causing false tenure splits.

## Fix

```go
// After (fixed)
if event.Company == "" {
    continue // Project-only events don't affect employment tenures
}
```

## Testing

- `hasInterveningCompanyEvents` returns `false` when only project-only events exist between dates
- `hasInterveningCompanyEvents` returns `true` when real company events intervene (BUG-009 preserved)
- `hasInterveningCompanyEvents` returns `false` for mix of project-only + same-company events
- `GroupEventsByCompany` produces single tenure with concurrent project events
- `GroupEventsByCompany` still splits tenures when real companies intervene

## Related

- BUG-009: CV tenure detection (introduced `hasInterveningCompanyEvents`)
- BUG-013: Bullet deduplication merges across companies
- BUG-014: Date calculation ignores primary company