### PR TITLE
fix(service): make bullet deduplication company-aware (BUG-013)

### DIFF
--- a/bugs/BUG-013-bullet-dedup-cross-company.md
+++ b/bugs/BUG-013-bullet-dedup-cross-company.md
@@ -1,0 +1,83 @@
+# BUG-013: Bullet deduplication merges entries across companies
+
+## Summary
+
+`deduplicateBullets()` uses normalized text as the sole deduplication key, with no
+company awareness. When two career events at different companies have identical
+descriptions, their bullets are merged into a single bullet with `SourceEventIDs`
+spanning multiple companies and wildly different date ranges.
+
+## Steps to Reproduce
+
+1. Import career events where identical descriptions exist at different companies
+   (e.g., "Acted as senior stabilising engineer during late-stage delivery pressure"
+   at both We Are Friday (Nov 2012) and BEIS (Oct 2019))
+2. Generate a CV via `kariya` TUI
+3. Observe company date ranges are corrupted
+
+## Expected Behavior
+
+Each company's entry should retain its own bullet with correct dates. BEIS should
+show Jun 2019 - Dec 2019.
+
+## Actual Behavior
+
+BEIS shows "Nov 2012 - Dec 2019" because the deduplication merged the We Are Friday
+bullet (Nov 2012) with the BEIS bullet (Oct 2019) into a single bullet with
+`SourceEventIDs` from both events. The date calculation then takes the min/max
+across all source events regardless of company.
+
+This affects any company with text matching another company's entries. It is
+especially damaging for recurring cross-cutting entries that appear identically
+across many companies (e.g., "Designed and delivered scalable backend services
+using Ruby on Rails..." appears at 16 different companies). After deduplication,
+these become a single bullet with 16 SourceEventIDs spanning 18 years.
+
+## Root Cause
+
+**File**: `internal/service/career/cv/bullet_generator.go:401-440`
+
+```go
+normalizedText := strings.ToLower(strings.TrimSpace(bullet.Text))
+
+if existing, exists := seen[normalizedText]; exists {
+    // MERGES SourceEventIDs from different companies
+    existing.SourceEventIDs = mergeUniqueStrings(existing.SourceEventIDs, bullet.SourceEventIDs)
+}
+```
+
+The deduplication key is text-only. Identical work descriptions at different
+employers are legitimate separate career events, not duplicates.
+
+## Fix Plan
+
+Make the deduplication key company-aware by including the primary company in the
+key. This requires resolving the primary company for each bullet before
+deduplication, or passing event context into the deduplication function.
+
+Option A - composite key using source event company:
+
+```go
+primaryCompany := resolvePrimaryCompany(bullet, eventMap)
+key := normalizedText + "|" + primaryCompany
+```
+
+Option B - deduplicate per-company instead of globally:
+
+Group bullets by company first, then deduplicate within each group.
+
+## Regression Tests
+
+- Bullets with identical text but different source companies are NOT merged
+- Bullets with identical text AND same source company ARE merged
+- Cross-cutting entries (16 copies across companies) produce 16 separate bullets
+- SourceEventIDs after dedup only contain events from the same company
+
+## Related
+
+- BUG-014: Date calculation ignores primary company (defence-in-depth fix)
+- BUG-012: Tenure detection project events
+
+## Severity
+
+- [x] High - CV displays incorrect employment dates and corrupted company sections

--- a/bugs/BUG-015-career-event-missing-association-validation.md
+++ b/bugs/BUG-015-career-event-missing-association-validation.md
@@ -1,0 +1,83 @@
+# BUG-015: CareerEvent accepts events with no company or project association
+
+## Summary
+
+`CareerEvent.Validate()` does not enforce that an event is associated with either
+a company or a project. Events with both `Company` and `Project` as empty strings
+pass validation and enter the system, causing downstream logic (deduplication,
+date calculation, tenure detection) to handle an invalid state defensively rather
+than rejecting it at the domain boundary.
+
+## Steps to Reproduce
+
+1. Create a `CareerEvent` with `Company: ""` and `Project: ""`
+2. Call `Validate()` on the event
+3. Observe it returns `nil` (no error)
+
+## Expected Behavior
+
+`Validate()` should return an error when both `Company` and `Project` are empty.
+Every career event must be associated with at least one organisational context.
+
+## Actual Behavior
+
+`Validate()` only checks `Text`, `Date`, `Tags`, and `Categories`. The `Company`
+and `Project` fields are completely unchecked. Events with no association pass
+through the service layer (`CaptureEvent`, `UpdateEvent`) without error.
+
+## Root Cause
+
+**File**: `internal/domain/career/event.go:26-48`
+
+```go
+func (ce *CareerEvent) Validate() error {
+    if err := ce.validateText(); err != nil { return err }
+    if err := ce.validateDate(); err != nil { return err }
+    if err := ce.validateTags(); err != nil { return err }
+    if err := ce.validateCategories(); err != nil { return err }
+    return nil
+    // No validateAssociation() call
+}
+```
+
+There is no `validateAssociation()` method requiring `Company != ""` or
+`Project != ""`.
+
+## Fix Plan
+
+Add a `validateAssociation()` method to `CareerEvent`:
+
+```go
+func (ce *CareerEvent) validateAssociation() error {
+    if strings.TrimSpace(ce.Company) == "" && strings.TrimSpace(ce.Project) == "" {
+        return errors.New("event must be associated with a company or project")
+    }
+    return nil
+}
+```
+
+Call it from `Validate()` alongside the existing validators.
+
+## Impact
+
+Existing tests that construct events with both fields empty will need updating to
+provide at least one association. The database layer (`gorm`) does not enforce
+`NOT NULL` on either column, so a migration may be needed for data integrity.
+
+## Regression Tests
+
+- Event with Company set and Project empty passes validation
+- Event with Project set and Company empty passes validation
+- Event with both Company and Project set passes validation
+- Event with both Company and Project empty fails validation
+- `CaptureEvent` rejects events with no association
+- `UpdateEvent` rejects events with no association
+
+## Related
+
+- BUG-013: Bullet deduplication merges across companies (empty company causes incorrect merging)
+- BUG-014: Date calculation ignores primary company
+
+## Severity
+
+- [x] Medium - Invalid data enters the system silently; downstream code must handle defensively

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"errors"
 	"fmt"
 	"io"
@@ -134,8 +133,8 @@ func run(args []string, out io.Writer, errOut io.Writer) int {
 			}
 		}
 
-		// Open database connection
-		db, err := sql.Open("sqlite", dbPath)
+		// Open database connection with WAL mode and busy timeout.
+		db, err := careersql.OpenDB(dbPath)
 		if err != nil {
 			fmt.Fprintf(errOut, "Error opening database at '%s': %v\n", dbPath, err)
 			return 1

--- a/internal/repository/career/sql/repositories.go
+++ b/internal/repository/career/sql/repositories.go
@@ -41,11 +41,27 @@ func NewRepositories(sqlDB *sql.DB) (*career.Repositories, error) {
 	return repos, nil
 }
 
+// OpenDB opens a SQLite database with WAL journal mode, a 5-second busy
+// timeout, and a single-connection pool. These settings prevent
+// SQLITE_BUSY errors on Windows where file locking is stricter.
+func OpenDB(dbPath string) (*sql.DB, error) {
+	dsn := dbPath + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)"
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, err
+	}
+
+	// SQLite does not support concurrent writers; serialise all access.
+	db.SetMaxOpenConns(1)
+
+	return db, nil
+}
+
 // NewRepositoriesFromPath creates all SQL repositories from a database file path.
 // This opens a new database connection and runs migrations.
 // The caller should call Close() when done.
 func NewRepositoriesFromPath(dbPath string) (*career.Repositories, error) {
-	sqlDB, err := sql.Open("sqlite", dbPath)
+	sqlDB, err := OpenDB(dbPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/career/cv/bullet_generator.go
+++ b/internal/service/career/cv/bullet_generator.go
@@ -167,8 +167,14 @@ func (bg *DefaultBulletGenerator) GenerateBullets(ctx context.Context,
 	// Filter by audience
 	bullets = bg.FilterByAudience(bullets, targetAudience)
 
-	// Deduplicate bullets with identical text (keeps highest confidence)
-	bullets = bg.deduplicateBullets(bullets)
+	// Build event map for company-aware deduplication (BUG-013).
+	eventMap := make(map[string]*career.CareerEvent, len(events))
+	for _, event := range events {
+		eventMap[event.ID] = event
+	}
+
+	// Deduplicate bullets with identical text at the same company (keeps highest confidence).
+	bullets = bg.deduplicateBullets(bullets, eventMap)
 
 	// Calculate scores
 	bullets = bg.calculateScores(bullets, targetRole, targetAudience)
@@ -398,38 +404,44 @@ func (bg *DefaultBulletGenerator) extractPrimaryCategory(categories []string) co
 	return ""
 }
 
-// deduplicateBullets removes bullets with identical text, keeping the one with highest confidence
-// When merging, it combines source IDs to preserve lineage information
-func (bg *DefaultBulletGenerator) deduplicateBullets(bullets []*Bullet) []*Bullet {
+// deduplicateBullets removes bullets with identical text at the same company,
+// keeping the one with highest confidence. Bullets at different companies with
+// identical text are kept separate (BUG-013). When merging, it combines source
+// IDs to preserve lineage information.
+func (bg *DefaultBulletGenerator) deduplicateBullets(bullets []*Bullet, eventMap map[string]*career.CareerEvent) []*Bullet {
 	if len(bullets) <= 1 {
 		return bullets
 	}
 
-	// Map to track unique bullets by normalized text
+	// Map to track unique bullets by normalized text + company (BUG-013).
 	seen := make(map[string]*Bullet)
 
 	for _, bullet := range bullets {
-		// Normalize text for comparison (lowercase, trim spaces)
+		// Normalize text for comparison (lowercase, trim spaces).
 		normalizedText := strings.ToLower(strings.TrimSpace(bullet.Text))
 
-		if existing, exists := seen[normalizedText]; exists {
-			// Merge: keep the one with higher confidence, combine source IDs
+		// Resolve primary company from source events (BUG-013).
+		company := resolvePrimaryCompany(bullet.SourceEventIDs, eventMap)
+		key := normalizedText + "|" + company
+
+		if existing, exists := seen[key]; exists {
+			// Merge: keep the one with higher confidence, combine source IDs.
 			if bullet.Confidence > existing.Confidence {
-				// Keep new bullet but merge source IDs from existing
+				// Keep new bullet but merge source IDs from existing.
 				bullet.SourceEventIDs = mergeUniqueStrings(bullet.SourceEventIDs, existing.SourceEventIDs)
 				bullet.SourceFactIDs = mergeUniqueStrings(bullet.SourceFactIDs, existing.SourceFactIDs)
-				seen[normalizedText] = bullet
+				seen[key] = bullet
 			} else {
-				// Keep existing but merge source IDs from new
+				// Keep existing but merge source IDs from new.
 				existing.SourceEventIDs = mergeUniqueStrings(existing.SourceEventIDs, bullet.SourceEventIDs)
 				existing.SourceFactIDs = mergeUniqueStrings(existing.SourceFactIDs, bullet.SourceFactIDs)
 			}
 		} else {
-			seen[normalizedText] = bullet
+			seen[key] = bullet
 		}
 	}
 
-	// Convert back to slice
+	// Convert back to slice.
 	result := make([]*Bullet, 0, len(seen))
 	for _, bullet := range seen {
 		result = append(result, bullet)
@@ -437,6 +449,32 @@ func (bg *DefaultBulletGenerator) deduplicateBullets(bullets []*Bullet) []*Bulle
 
 	bg.logger.Info("Deduplicated bullets: %d -> %d", len(bullets), len(result))
 	return result
+}
+
+// resolvePrimaryCompany determines the primary company for a bullet by counting
+// which company appears most frequently across its source events (BUG-013).
+func resolvePrimaryCompany(sourceEventIDs []string, eventMap map[string]*career.CareerEvent) string {
+	if len(sourceEventIDs) == 0 || len(eventMap) == 0 {
+		return ""
+	}
+
+	companyCounts := make(map[string]int)
+	for _, eid := range sourceEventIDs {
+		if event, ok := eventMap[eid]; ok && event.Company != "" {
+			companyCounts[event.Company]++
+		}
+	}
+
+	primaryCompany := ""
+	maxCount := 0
+	for company, count := range companyCounts {
+		if count > maxCount {
+			maxCount = count
+			primaryCompany = company
+		}
+	}
+
+	return primaryCompany
 }
 
 // mergeUniqueStrings merges two string slices, removing duplicates

--- a/internal/service/career/cv/bullet_generator.go
+++ b/internal/service/career/cv/bullet_generator.go
@@ -404,6 +404,13 @@ func (bg *DefaultBulletGenerator) extractPrimaryCategory(categories []string) co
 	return ""
 }
 
+// dedupKey is a struct-based key for bullet deduplication, avoiding string
+// delimiter collisions (e.g. company names containing "|").
+type dedupKey struct {
+	text    string
+	company string
+}
+
 // deduplicateBullets removes bullets with identical text at the same company,
 // keeping the one with highest confidence. Bullets at different companies with
 // identical text are kept separate (BUG-013). When merging, it combines source
@@ -414,7 +421,7 @@ func (bg *DefaultBulletGenerator) deduplicateBullets(bullets []*Bullet, eventMap
 	}
 
 	// Map to track unique bullets by normalized text + company (BUG-013).
-	seen := make(map[string]*Bullet)
+	seen := make(map[dedupKey]*Bullet)
 
 	for _, bullet := range bullets {
 		// Normalize text for comparison (lowercase, trim spaces).
@@ -422,7 +429,15 @@ func (bg *DefaultBulletGenerator) deduplicateBullets(bullets []*Bullet, eventMap
 
 		// Resolve primary company from source events (BUG-013).
 		company := resolvePrimaryCompany(bullet.SourceEventIDs, eventMap)
-		key := normalizedText + "|" + company
+
+		// When company cannot be resolved (no company on source events),
+		// fall back to the first SourceEventID to prevent unrelated bullets
+		// from merging under an empty key (BUG-015 defence-in-depth).
+		if company == "" && len(bullet.SourceEventIDs) > 0 {
+			company = bullet.SourceEventIDs[0]
+		}
+
+		key := dedupKey{text: normalizedText, company: company}
 
 		if existing, exists := seen[key]; exists {
 			// Merge: keep the one with higher confidence, combine source IDs.
@@ -453,6 +468,8 @@ func (bg *DefaultBulletGenerator) deduplicateBullets(bullets []*Bullet, eventMap
 
 // resolvePrimaryCompany determines the primary company for a bullet by counting
 // which company appears most frequently across its source events (BUG-013).
+// When multiple companies are tied, the lexicographically smallest name wins
+// to ensure deterministic results across runs.
 func resolvePrimaryCompany(sourceEventIDs []string, eventMap map[string]*career.CareerEvent) string {
 	if len(sourceEventIDs) == 0 || len(eventMap) == 0 {
 		return ""
@@ -465,11 +482,18 @@ func resolvePrimaryCompany(sourceEventIDs []string, eventMap map[string]*career.
 		}
 	}
 
+	// Sort company names for deterministic tie-breaking.
+	companies := make([]string, 0, len(companyCounts))
+	for company := range companyCounts {
+		companies = append(companies, company)
+	}
+	sort.Strings(companies)
+
 	primaryCompany := ""
 	maxCount := 0
-	for company, count := range companyCounts {
-		if count > maxCount {
-			maxCount = count
+	for _, company := range companies {
+		if companyCounts[company] > maxCount {
+			maxCount = companyCounts[company]
 			primaryCompany = company
 		}
 	}

--- a/internal/service/career/cv/bullet_generator.go
+++ b/internal/service/career/cv/bullet_generator.go
@@ -433,8 +433,13 @@ func (bg *DefaultBulletGenerator) deduplicateBullets(bullets []*Bullet, eventMap
 		// When company cannot be resolved (no company on source events),
 		// fall back to the first SourceEventID to prevent unrelated bullets
 		// from merging under an empty key (BUG-015 defence-in-depth).
-		if company == "" && len(bullet.SourceEventIDs) > 0 {
-			company = bullet.SourceEventIDs[0]
+		// If SourceEventIDs is also empty, use bullet ID as last resort.
+		if company == "" {
+			if len(bullet.SourceEventIDs) > 0 {
+				company = bullet.SourceEventIDs[0]
+			} else {
+				company = bullet.ID
+			}
 		}
 
 		key := dedupKey{text: normalizedText, company: company}

--- a/internal/service/career/cv/bullet_generator_test.go
+++ b/internal/service/career/cv/bullet_generator_test.go
@@ -3,6 +3,7 @@ package cv
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strings"
 
@@ -1147,5 +1148,88 @@ var _ = Describe("BUG-008: ScoringConfig integration", func() {
 			Expect(technicalBullet).NotTo(BeNil())
 			Expect(technicalBullet.Category).To(Equal(constants.CompetencyTechnical))
 		})
+	})
+})
+
+// BUG-013: Bullet deduplication must be company-aware.
+var _ = Describe("BUG-013: Company-aware bullet deduplication", func() {
+	var (
+		generator BulletGenerator
+		log       *logger.Logger
+		ctx       context.Context
+	)
+
+	BeforeEach(func() {
+		log = logger.New(io.Discard, logger.InfoLevel)
+		generator = NewBulletGenerator(log, nil)
+		ctx = context.Background()
+	})
+
+	It("should NOT merge bullets with identical text from different companies", func() {
+		events := []*career.CareerEvent{
+			fixtures.EventWith("e-friday", "Acted as senior stabilising engineer during late-stage delivery pressure", "We Are Friday", ""),
+			fixtures.EventWith("e-beis", "Acted as senior stabilising engineer during late-stage delivery pressure", "BEIS", ""),
+		}
+
+		bullets, err := generator.GenerateBullets(ctx, events, nil, nil, "", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bullets).To(HaveLen(2), "identical text at different companies must produce separate bullets")
+	})
+
+	It("should merge bullets with identical text from the same company", func() {
+		events := []*career.CareerEvent{
+			fixtures.EventWith("e1", "Built scalable backend services", "Acme Corp", "Project A"),
+			fixtures.EventWith("e2", "Built scalable backend services", "Acme Corp", "Project B"),
+		}
+
+		bullets, err := generator.GenerateBullets(ctx, events, nil, nil, "", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bullets).To(HaveLen(1), "identical text at the same company should be merged")
+	})
+
+	It("should produce separate bullets for cross-cutting entries across many companies", func() {
+		companies := []string{"Company A", "Company B", "Company C", "Company D", "Company E"}
+		events := make([]*career.CareerEvent, len(companies))
+		for i, company := range companies {
+			events[i] = fixtures.EventWith(
+				fmt.Sprintf("e-%d", i+1),
+				"Designed and delivered scalable backend services using Ruby on Rails",
+				company,
+				"",
+			)
+		}
+
+		bullets, err := generator.GenerateBullets(ctx, events, nil, nil, "", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bullets).To(HaveLen(len(companies)),
+			"cross-cutting entries across %d companies must produce %d separate bullets", len(companies), len(companies))
+	})
+
+	It("should keep SourceEventIDs scoped to the same company after dedup", func() {
+		events := []*career.CareerEvent{
+			fixtures.EventWith("e-friday-1", "Led delivery of key features", "We Are Friday", ""),
+			fixtures.EventWith("e-friday-2", "Led delivery of key features", "We Are Friday", ""),
+			fixtures.EventWith("e-beis-1", "Led delivery of key features", "BEIS", ""),
+		}
+
+		bullets, err := generator.GenerateBullets(ctx, events, nil, nil, "", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bullets).To(HaveLen(2), "should produce one bullet per company")
+
+		// Build a lookup of company per event for verification.
+		eventCompany := map[string]string{
+			"e-friday-1": "We Are Friday",
+			"e-friday-2": "We Are Friday",
+			"e-beis-1":   "BEIS",
+		}
+
+		for _, bullet := range bullets {
+			companies := map[string]bool{}
+			for _, eid := range bullet.SourceEventIDs {
+				companies[eventCompany[eid]] = true
+			}
+			Expect(companies).To(HaveLen(1),
+				"SourceEventIDs should only reference events from one company, got %v", bullet.SourceEventIDs)
+		}
 	})
 })

--- a/internal/service/career/cv/bullet_generator_test.go
+++ b/internal/service/career/cv/bullet_generator_test.go
@@ -1232,4 +1232,39 @@ var _ = Describe("BUG-013: Company-aware bullet deduplication", func() {
 				"SourceEventIDs should only reference events from one company, got %v", bullet.SourceEventIDs)
 		}
 	})
+
+	It("should resolve primary company deterministically when counts are tied", func() {
+		// Two companies each appear once - tie must be broken deterministically.
+		events := []*career.CareerEvent{
+			fixtures.EventWith("e-zebra", "Implemented CI/CD pipelines", "Zebra Inc", ""),
+			fixtures.EventWith("e-alpha", "Implemented CI/CD pipelines", "Alpha Corp", ""),
+		}
+
+		// Run multiple times to verify determinism.
+		var firstResult string
+		for i := 0; i < 10; i++ {
+			bullets, err := generator.GenerateBullets(ctx, events, nil, nil, "", "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bullets).To(HaveLen(2), "different companies must produce separate bullets")
+			if i == 0 {
+				firstResult = bullets[0].Text
+			}
+			Expect(bullets[0].Text).To(Equal(firstResult),
+				"iteration %d: primary company resolution must be deterministic", i)
+		}
+	})
+
+	It("should not merge bullets from events missing from the event map", func() {
+		// Events with IDs that won't resolve to a company should not merge
+		// with each other under an empty key (BUG-015 defence-in-depth).
+		events := []*career.CareerEvent{
+			fixtures.EventWith("e1", "Built monitoring dashboards", "", "Project X"),
+			fixtures.EventWith("e2", "Built monitoring dashboards", "", "Project Y"),
+		}
+
+		bullets, err := generator.GenerateBullets(ctx, events, nil, nil, "", "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bullets).To(HaveLen(2),
+			"bullets from events with no company should not merge under an empty key")
+	})
 })

--- a/internal/service/career/cv/bullet_generator_test.go
+++ b/internal/service/career/cv/bullet_generator_test.go
@@ -1234,23 +1234,23 @@ var _ = Describe("BUG-013: Company-aware bullet deduplication", func() {
 	})
 
 	It("should resolve primary company deterministically when counts are tied", func() {
-		// Two companies each appear once - tie must be broken deterministically.
-		events := []*career.CareerEvent{
-			fixtures.EventWith("e-zebra", "Implemented CI/CD pipelines", "Zebra Inc", ""),
-			fixtures.EventWith("e-alpha", "Implemented CI/CD pipelines", "Alpha Corp", ""),
+		// Build an event map where a bullet has source events from two
+		// companies with equal counts - a genuine tie scenario.
+		eventMap := map[string]*career.CareerEvent{
+			"e-zebra": fixtures.EventWith("e-zebra", "work", "Zebra Inc", ""),
+			"e-alpha": fixtures.EventWith("e-alpha", "work", "Alpha Corp", ""),
 		}
+		sourceIDs := []string{"e-zebra", "e-alpha"}
 
 		// Run multiple times to verify determinism.
-		var firstResult string
-		for i := 0; i < 10; i++ {
-			bullets, err := generator.GenerateBullets(ctx, events, nil, nil, "", "")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(bullets).To(HaveLen(2), "different companies must produce separate bullets")
-			if i == 0 {
-				firstResult = bullets[0].Text
-			}
-			Expect(bullets[0].Text).To(Equal(firstResult),
-				"iteration %d: primary company resolution must be deterministic", i)
+		first := resolvePrimaryCompany(sourceIDs, eventMap)
+		Expect(first).To(Equal("Alpha Corp"),
+			"lexicographically smallest company should win on tie")
+
+		for i := 0; i < 20; i++ {
+			result := resolvePrimaryCompany(sourceIDs, eventMap)
+			Expect(result).To(Equal(first),
+				"iteration %d: tie-breaking must be deterministic", i)
 		}
 	})
 
@@ -1266,5 +1266,20 @@ var _ = Describe("BUG-013: Company-aware bullet deduplication", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(bullets).To(HaveLen(2),
 			"bullets from events with no company should not merge under an empty key")
+	})
+
+	It("should not merge orphaned bullets with no SourceEventIDs", func() {
+		// Bullets with no SourceEventIDs and no company should use their
+		// bullet ID as fallback key to prevent incorrect merging.
+		bg := generator.(*DefaultBulletGenerator)
+		bullets := []*Bullet{
+			{ID: "b1", Text: "Identical orphaned text", SourceEventIDs: nil},
+			{ID: "b2", Text: "Identical orphaned text", SourceEventIDs: nil},
+		}
+		eventMap := map[string]*career.CareerEvent{}
+
+		result := bg.deduplicateBullets(bullets, eventMap)
+		Expect(result).To(HaveLen(2),
+			"orphaned bullets with distinct IDs must not merge under an empty key")
 	})
 })

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/baphled/kariya/internal/repository/career"
-	_ "modernc.org/sqlite"
+	careersql "github.com/baphled/kariya/internal/repository/career/sql"
 )
 
 // SetupTestDB creates a test database with all migrations applied.
@@ -25,7 +25,7 @@ func SetupTestDB(t testing.TB) (*sql.DB, func()) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
 
-	db, err := sql.Open("sqlite", dbPath)
+	db, err := careersql.OpenDB(dbPath)
 	if err != nil {
 		t.Fatalf("failed to open test db: %v", err)
 	}
@@ -65,7 +65,7 @@ func SetupTestDBWithPath(t testing.TB) (string, *sql.DB, func()) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test.db")
 
-	db, err := sql.Open("sqlite", dbPath)
+	db, err := careersql.OpenDB(dbPath)
 	if err != nil {
 		t.Fatalf("failed to open test db at %s: %v", dbPath, err)
 	}

--- a/internal/testutil/e2e/helpers.go
+++ b/internal/testutil/e2e/helpers.go
@@ -111,8 +111,8 @@ func Setup(t TestingT) *TestEnv {
 	configPath := filepath.Join(tmpDir, "config.yaml")
 	prevConfigPath := config.SwapConfigPathForTesting(configPath)
 
-	// Open database connection
-	db, err := sql.Open("sqlite", dbPath)
+	// Open database connection with WAL mode and busy timeout.
+	db, err := careersql.OpenDB(dbPath)
 	if err != nil {
 		config.SetConfigPathForTesting(prevConfigPath) // Restore on failure
 		t.Fatalf("failed to open test db: %v", err)
@@ -209,8 +209,8 @@ func SetupShared() {
 
 	dbPath := filepath.Join(sharedTmpDir, "e2e_shared.db")
 
-	// Open database connection
-	db, err := sql.Open("sqlite", dbPath)
+	// Open database connection with WAL mode and busy timeout.
+	db, err := careersql.OpenDB(dbPath)
 	if err != nil {
 		panic("failed to open shared test db: " + err.Error())
 	}
@@ -395,8 +395,8 @@ func SetupWithOnboarding(t TestingT) *TestEnv {
 	configPath := filepath.Join(tmpDir, "config.yaml")
 	prevConfigPath := config.SwapConfigPathForTesting(configPath)
 
-	// Open database connection
-	db, err := sql.Open("sqlite", dbPath)
+	// Open database connection with WAL mode and busy timeout.
+	db, err := careersql.OpenDB(dbPath)
 	if err != nil {
 		config.SetConfigPathForTesting(prevConfigPath) // Restore on failure
 		_ = os.RemoveAll(tmpDir)                       // Clean up temp dir on failure


### PR DESCRIPTION
## Summary

- **BUG-013**: `deduplicateBullets()` used normalized text as the sole dedup key, merging bullets with identical descriptions across different companies into a single bullet. This caused `SourceEventIDs` to span multiple employers and corrupted downstream date range calculations (e.g., BEIS showing "Nov 2012 - Dec 2019" from a merged We Are Friday event).
- The dedup key is now a struct-based composite of `{text, company}`, resolved from source event IDs via a new `resolvePrimaryCompany()` helper. Identical text at the same company is still merged; identical text across companies is kept separate.
- Addressed Copilot review feedback: deterministic lexicographic tie-breaking in `resolvePrimaryCompany`, struct-based dedup key (avoids pipe delimiter collisions), fallback to first SourceEventID when company cannot be resolved, and bullet ID fallback for orphaned bullets with no SourceEventIDs.
- Filed **BUG-015** for missing Company/Project validation on `CareerEvent.Validate()`.
- **SQLite locking fix**: Centralised all SQLite connection setup in `OpenDB()` with WAL journal mode, 5-second busy timeout, and single-connection pool. Fixes `SQLITE_BUSY` errors in Windows CI E2E tests.
- Adds 7 regression tests covering: cross-company separation, same-company merging, cross-cutting entries across 5 companies, SourceEventID scoping validation, deterministic tie-breaking (direct unit test), empty-company fallback, and orphaned bullet dedup.

## Changes

| File | Change |
|------|--------|
| `internal/service/career/cv/bullet_generator.go` | Struct-based dedup key; deterministic `resolvePrimaryCompany()` with lexicographic tie-breaking; empty-company fallback to first SourceEventID; bullet ID fallback for orphaned bullets; event map built in `GenerateBullets()` |
| `internal/service/career/cv/bullet_generator_test.go` | 7 new BUG-013 regression tests |
| `internal/repository/career/sql/repositories.go` | New `OpenDB()` helper with WAL mode, busy_timeout, and `SetMaxOpenConns(1)` |
| `cmd/cli/main.go` | Use `careersql.OpenDB()` instead of bare `sql.Open()` |
| `internal/testutil/db.go` | Use `careersql.OpenDB()` for test DB setup |
| `internal/testutil/e2e/helpers.go` | Use `careersql.OpenDB()` in all 3 E2E setup functions |
| `bugs/BUG-013-bullet-dedup-cross-company.md` | Bug report documenting root cause and fix |
| `bugs/BUG-015-career-event-missing-association-validation.md` | Bug report for missing Company/Project validation |

## Testing

- All 363 tests in the CV package pass (including 7 new)
- All E2E tests pass with race detector
- `go vet` and `gofmt` clean
- SQLite locking fix verified locally; Windows CI previously failed with 31 SQLITE_BUSY errors