### PR TITLE
fix(cv): filter dates by primary company in grouping (BUG-014)

### DIFF
--- a/bugs/BUG-014-date-calc-ignores-primary-company.md
+++ b/bugs/BUG-014-date-calc-ignores-primary-company.md
@@ -81,7 +81,7 @@ against any future scenario where SourceEventIDs span multiple companies.
 - Date range computed using only events from the primary company
 - Bullet with SourceEventIDs from BEIS (2019) and We Are Friday (2012) assigned to
   BEIS produces dates Jun-Dec 2019 (not Nov 2012 - Dec 2019)
-- Cross-cutting bullet with 16 source companies produces dates for winning company only
+- Cross-cutting bullet with multiple source companies produces dates for winning company only
 
 ## Related
 

--- a/bugs/BUG-014-date-calc-ignores-primary-company.md
+++ b/bugs/BUG-014-date-calc-ignores-primary-company.md
@@ -1,0 +1,93 @@
+# BUG-014: Date calculation in groupBulletsByCompany ignores primary company
+
+## Summary
+
+`groupBulletsByCompany()` computes `earliestDate` and `latestDate` for each bullet
+by iterating over ALL `SourceEventIDs` regardless of which company those events
+belong to. When a bullet has cross-company SourceEventIDs (caused by BUG-013), the
+date range spans multiple companies and corrupts the company section dates.
+
+## Steps to Reproduce
+
+1. Have a bullet with SourceEventIDs from multiple companies (see BUG-013)
+2. Generate a CV via `kariya` TUI
+3. Observe company sections with impossible date ranges (e.g., BEIS: Nov 2012 - Dec 2019)
+
+## Expected Behavior
+
+A bullet assigned to BEIS should compute its date range using only BEIS events
+from its SourceEventIDs, producing Jun 2019 - Dec 2019.
+
+## Actual Behavior
+
+The date range is computed across ALL source events. If the bullet's SourceEventIDs
+include a We Are Friday event from Nov 2012 and a BEIS event from Oct 2019, the
+bullet gets `earliestDate = Nov 2012`, which propagates to the BEIS company
+section start date.
+
+## Root Cause
+
+**File**: `internal/service/career/cv/section_builder.go:421-435`
+
+```go
+for _, eventID := range bullet.SourceEventIDs {
+    if event, exists := eventMap[eventID]; exists {
+        if event.Company != "" {
+            companyCounts[event.Company]++
+            // Dates computed across ALL companies - no filtering
+            if earliestDate.IsZero() || event.Date.Before(earliestDate) {
+                earliestDate = event.Date
+            }
+            if latestDate.IsZero() || event.Date.After(latestDate) {
+                latestDate = event.Date
+            }
+        }
+    }
+}
+```
+
+The code determines `primaryCompany` as the most frequent company in
+`companyCounts`, but computes dates across all companies in the same pass. It
+should recompute dates using only events matching `primaryCompany`.
+
+## Fix Plan
+
+Split the loop into two passes, or recompute dates after determining the primary
+company:
+
+```go
+// After determining primaryCompany, filter dates
+earliestDate = time.Time{}
+latestDate = time.Time{}
+for _, eventID := range bullet.SourceEventIDs {
+    if event, exists := eventMap[eventID]; exists {
+        if event.Company == primaryCompany {
+            if earliestDate.IsZero() || event.Date.Before(earliestDate) {
+                earliestDate = event.Date
+            }
+            if latestDate.IsZero() || event.Date.After(latestDate) {
+                latestDate = event.Date
+            }
+        }
+    }
+}
+```
+
+This is a defence-in-depth fix. Even after BUG-013 is resolved, this protects
+against any future scenario where SourceEventIDs span multiple companies.
+
+## Regression Tests
+
+- Date range computed using only events from the primary company
+- Bullet with SourceEventIDs from BEIS (2019) and We Are Friday (2012) assigned to
+  BEIS produces dates Jun-Dec 2019 (not Nov 2012 - Dec 2019)
+- Cross-cutting bullet with 16 source companies produces dates for winning company only
+
+## Related
+
+- BUG-013: Bullet deduplication merges across companies (root cause of cross-company SourceEventIDs)
+- BUG-012: Tenure detection project events
+
+## Severity
+
+- [x] High - CV displays incorrect employment dates

--- a/internal/service/career/cv/section_builder.go
+++ b/internal/service/career/cv/section_builder.go
@@ -417,19 +417,12 @@ func (sb *DefaultSectionBuilder) groupBulletsByCompany(bullets []*career.CVBulle
 	skippedCount := 0
 
 	for _, bullet := range bullets {
+		// First pass: count events per company to determine the primary company.
 		companyCounts := make(map[string]int)
-		var earliestDate, latestDate time.Time
-
 		for _, eventID := range bullet.SourceEventIDs {
 			if event, exists := eventMap[eventID]; exists {
 				if event.Company != "" {
 					companyCounts[event.Company]++
-					if earliestDate.IsZero() || event.Date.Before(earliestDate) {
-						earliestDate = event.Date
-					}
-					if latestDate.IsZero() || event.Date.After(latestDate) {
-						latestDate = event.Date
-					}
 				}
 			}
 		}
@@ -447,6 +440,23 @@ func (sb *DefaultSectionBuilder) groupBulletsByCompany(bullets []*career.CVBulle
 		if primaryCompany == "" {
 			skippedCount++
 			continue
+		}
+
+		// Second pass: compute dates using only events from the primary company.
+		// BUG-014: Previously dates were computed across ALL companies in a single
+		// pass, which corrupted date ranges when SourceEventIDs spanned companies.
+		var earliestDate, latestDate time.Time
+		for _, eventID := range bullet.SourceEventIDs {
+			if event, exists := eventMap[eventID]; exists {
+				if event.Company == primaryCompany {
+					if earliestDate.IsZero() || event.Date.Before(earliestDate) {
+						earliestDate = event.Date
+					}
+					if latestDate.IsZero() || event.Date.After(latestDate) {
+						latestDate = event.Date
+					}
+				}
+			}
 		}
 
 		bulletInfos = append(bulletInfos, bulletInfo{

--- a/internal/service/career/cv/section_builder_test.go
+++ b/internal/service/career/cv/section_builder_test.go
@@ -463,4 +463,143 @@ var _ = Describe("DefaultSectionBuilder", func() {
 			Expect(expSection.Content[1].Header).To(Equal("OldCorp"))
 		})
 	})
+
+	// BUG-014: Date calculation in groupBulletsByCompany ignores primary company.
+	Context("BUG-014: date calculation filters by primary company", func() {
+		It("should compute date range using only events from the primary company", func() {
+			// Bullet has SourceEventIDs from two companies:
+			// - BEIS event from Jun 2019
+			// - BEIS event from Dec 2019
+			// - We Are Friday event from Nov 2012
+			// Primary company is BEIS (2 events vs 1), so dates should be Jun 2019 - Dec 2019.
+
+			beisEvent1 := fixtures.EventWith("beis1", "Policy work", "BEIS", "")
+			beisEvent1.Date = time.Date(2019, 6, 15, 0, 0, 0, 0, time.UTC)
+
+			beisEvent2 := fixtures.EventWith("beis2", "Delivery work", "BEIS", "")
+			beisEvent2.Date = time.Date(2019, 12, 15, 0, 0, 0, 0, time.UTC)
+
+			wafEvent := fixtures.EventWith("waf1", "Old project", "We Are Friday", "")
+			wafEvent.Date = time.Date(2012, 11, 15, 0, 0, 0, 0, time.UTC)
+
+			events := []*career.CareerEvent{beisEvent1, beisEvent2, wafEvent}
+
+			// Bullet references all three events (cross-company SourceEventIDs from BUG-013).
+			bullet := &career.CVBullet{
+				ID:             "bullet-cross",
+				Text:           "Cross-company bullet",
+				SourceEventIDs: []string{"beis1", "beis2", "waf1"},
+				Rank:           0.8,
+			}
+			bullets := []*career.CVBullet{bullet}
+
+			sections, err := builder.BuildSections(ctx, bullets, events, []*career.Fact{}, "senior_ic", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Find experience section.
+			var expSection *career.CVSection
+			for _, s := range sections {
+				if s.SectionType == "experience" {
+					expSection = s
+					break
+				}
+			}
+			Expect(expSection).NotTo(BeNil())
+
+			// The bullet should be assigned to BEIS (primary company).
+			Expect(expSection.Content).To(HaveLen(1))
+			Expect(expSection.Content[0].Header).To(Equal("BEIS"))
+
+			// Dates should reflect BEIS events only: Jun 2019 - Dec 2019.
+			Expect(expSection.Content[0].StartDate).To(Equal("Jun 2019"))
+			Expect(expSection.Content[0].EndDate).To(Equal("Dec 2019"))
+		})
+
+		It("should produce correct dates for a cross-cutting bullet with many source companies", func() {
+			// Bullet with events from 3 companies: CompanyA (x3, 2023), CompanyB (x1, 2020), CompanyC (x1, 2018).
+			// Primary = CompanyA. Dates should only reflect CompanyA events.
+
+			eventA1 := fixtures.EventWith("a1", "Work A1", "CompanyA", "")
+			eventA1.Date = time.Date(2023, 3, 1, 0, 0, 0, 0, time.UTC)
+
+			eventA2 := fixtures.EventWith("a2", "Work A2", "CompanyA", "")
+			eventA2.Date = time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC)
+
+			eventA3 := fixtures.EventWith("a3", "Work A3", "CompanyA", "")
+			eventA3.Date = time.Date(2023, 9, 1, 0, 0, 0, 0, time.UTC)
+
+			eventB := fixtures.EventWith("b1", "Work B", "CompanyB", "")
+			eventB.Date = time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+			eventC := fixtures.EventWith("c1", "Work C", "CompanyC", "")
+			eventC.Date = time.Date(2018, 5, 1, 0, 0, 0, 0, time.UTC)
+
+			events := []*career.CareerEvent{eventA1, eventA2, eventA3, eventB, eventC}
+
+			bullet := &career.CVBullet{
+				ID:             "bullet-multi",
+				Text:           "Multi-company bullet",
+				SourceEventIDs: []string{"a1", "a2", "a3", "b1", "c1"},
+				Rank:           0.8,
+			}
+			bullets := []*career.CVBullet{bullet}
+
+			sections, err := builder.BuildSections(ctx, bullets, events, []*career.Fact{}, "senior_ic", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Find experience section.
+			var expSection *career.CVSection
+			for _, s := range sections {
+				if s.SectionType == "experience" {
+					expSection = s
+					break
+				}
+			}
+			Expect(expSection).NotTo(BeNil())
+
+			// Should be assigned to CompanyA (3 events, most frequent).
+			Expect(expSection.Content).To(HaveLen(1))
+			Expect(expSection.Content[0].Header).To(Equal("CompanyA"))
+
+			// Dates should be Mar 2023 - Sep 2023 (CompanyA only), NOT May 2018 - Sep 2023.
+			Expect(expSection.Content[0].StartDate).To(Equal("Mar 2023"))
+			Expect(expSection.Content[0].EndDate).To(Equal("Sep 2023"))
+		})
+
+		It("should handle a single-company bullet without date corruption", func() {
+			// Sanity check: a bullet with events from only one company should still work.
+
+			event1 := fixtures.EventWith("e1", "Work 1", "SingleCo", "")
+			event1.Date = time.Date(2021, 4, 1, 0, 0, 0, 0, time.UTC)
+
+			event2 := fixtures.EventWith("e2", "Work 2", "SingleCo", "")
+			event2.Date = time.Date(2021, 8, 1, 0, 0, 0, 0, time.UTC)
+
+			events := []*career.CareerEvent{event1, event2}
+
+			bullet := &career.CVBullet{
+				ID:             "bullet-single",
+				Text:           "Single-company bullet",
+				SourceEventIDs: []string{"e1", "e2"},
+				Rank:           0.8,
+			}
+			bullets := []*career.CVBullet{bullet}
+
+			sections, err := builder.BuildSections(ctx, bullets, events, []*career.Fact{}, "senior_ic", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			var expSection *career.CVSection
+			for _, s := range sections {
+				if s.SectionType == "experience" {
+					expSection = s
+					break
+				}
+			}
+			Expect(expSection).NotTo(BeNil())
+			Expect(expSection.Content).To(HaveLen(1))
+			Expect(expSection.Content[0].Header).To(Equal("SingleCo"))
+			Expect(expSection.Content[0].StartDate).To(Equal("Apr 2021"))
+			Expect(expSection.Content[0].EndDate).To(Equal("Aug 2021"))
+		})
+	})
 })


### PR DESCRIPTION
## Summary

- **BUG-014**: `groupBulletsByCompany()` computed `earliestDate`/`latestDate` across ALL source events regardless of company, corrupting company section dates when a bullet had cross-company `SourceEventIDs`
- Split the date computation into two passes: first determines the primary company (most frequent), then recomputes dates using only that company's events
- Added 3 regression tests covering cross-company date filtering, multi-company bullets, and single-company sanity check

## Root Cause

When a bullet had `SourceEventIDs` from multiple companies (e.g., from BUG-013 cross-company dedup), the date range spanned all companies. A bullet assigned to BEIS with a stray We Are Friday event from 2012 would show `Nov 2012 - Dec 2019` instead of `Jun 2019 - Dec 2019`.

## Changes

- `internal/service/career/cv/section_builder.go`: Refactored `groupBulletsByCompany` to use two-pass approach — count companies first, then compute dates filtered by primary company only
- `internal/service/career/cv/section_builder_test.go`: Added 3 BUG-014 regression tests
- `bugs/BUG-014-date-calc-ignores-primary-company.md`: Bug report

## Testing

- 359/359 tests pass (including 3 new regression tests)
- Build passes, formatting and vet clean