### PR TITLE
fix(intents): fix skill detail modal showing wrong skill (BUG-016)

### DIFF
--- a/bugs/BUG-016-skill-view-wrong-id.md
+++ b/bugs/BUG-016-skill-view-wrong-id.md
@@ -1,0 +1,118 @@
+# BUG-016: Skill detail modal shows wrong skill when viewing from list
+
+## Summary
+
+When viewing a skill from the skills list, the detail modal displays the wrong
+skill. Subsequent edit and delete actions from within the detail modal also
+operate on the wrong skill, risking data corruption.
+
+## Steps to Reproduce
+
+1. Navigate to Manage Skills
+2. Wait for the skills list to load (with 2+ skills)
+3. Use arrow keys to navigate to any skill other than the first one
+4. Press Enter to view the skill detail
+5. Observe the detail modal shows a different skill (the first one)
+6. From the detail modal, press `e` to edit or `d` to delete
+7. Observe the edit/delete operates on the wrong skill
+
+## Expected Behavior
+
+The detail modal should display the skill the user selected. Edit and delete
+actions from the modal should operate on that same skill.
+
+## Actual Behavior
+
+The detail modal always shows the skill at index 0 of `i.skills` (or whichever
+stale index `i.selectedIndex` holds), regardless of which skill the user
+selected in the list screen. Edit and delete from the modal cascade the error.
+
+## Root Cause
+
+**File**: `internal/cli/intents/skills_management/helpers.go:269-275`
+
+```go
+func (i *Intent) openViewDetailModal() tea.Cmd {
+    if len(i.skills) == 0 || i.selectedIndex >= len(i.skills) {
+        return nil
+    }
+    skill := i.skills[i.selectedIndex]   // BUG: stale index
+    i.selectedSkill = skill              // Overrides the correct value
+    ...
+}
+```
+
+There are two problems:
+
+1. **Stale `i.selectedIndex`**: The intent maintains its own `selectedIndex`
+   field which is only synced once during `handleSkillsLoaded()` via
+   `syncTableSelection()`. After that, user navigation updates the screen's
+   `tableBehavior.selectedIndex`, but the intent's `selectedIndex` stays at 0.
+
+2. **Two separate TableBehavior instances**: The intent creates its own
+   `tableBehavior` in `NewIntent()`, and the `SkillsListScreen` creates a
+   separate one in `NewSkillsListScreen()`. The user navigates the screen's
+   table, but `syncTableSelection()` reads from the intent's table which is
+   never navigated.
+
+The call chain that triggers the bug:
+
+1. User presses Enter on the list screen
+2. `SkillsListScreen.handleViewAction()` correctly retrieves the selected
+   `*career.Skill` via `tableBehavior.GetSelectedItem()` and passes it in
+   a `NavigateResult`
+3. `handleNavigateData("view")` correctly sets `i.selectedSkill = skill`
+4. Then calls `openViewDetailModal()` which **overrides** `i.selectedSkill`
+   with `i.skills[i.selectedIndex]` (the wrong skill)
+
+The edit and delete paths from the list screen (pressing `e` or `d` directly)
+are NOT affected because they pass the skill directly to `openAddEditModal()`
+and `openDeleteModal()` without calling `openViewDetailModal()`.
+
+However, edit and delete from within the detail modal ARE affected because
+`handleViewDetailModalUpdate()` uses the now-incorrect `i.selectedSkill`.
+
+## Fix Plan
+
+Modify `openViewDetailModal()` to use `i.selectedSkill` (already correctly set
+by `handleNavigateData()`) instead of re-indexing via `i.skills[i.selectedIndex]`:
+
+```go
+func (i *Intent) openViewDetailModal() tea.Cmd {
+    if i.selectedSkill == nil {
+        return nil
+    }
+
+    skill := i.selectedSkill
+
+    eventCount := 0
+    if i.eventCounts != nil {
+        eventCount = i.eventCounts[skill.ID]
+    }
+
+    width, height := i.getTerminalDimensions()
+
+    i.viewDetailModal = modals.NewDetailModal(skill, i.Theme(), eventCount, nil)
+    i.viewDetailModal.SetDimensions(width, height)
+    i.viewDetailModal.Show()
+
+    return nil
+}
+```
+
+## Regression Tests
+
+- Navigate to non-first skill and view: detail modal shows the correct skill
+- View a skill then edit from modal: edit modal receives the correct skill
+- View a skill then delete from modal: delete confirmation uses the correct skill ID
+- View with no selected skill (nil): returns nil without panic
+
+## Related
+
+- `internal/cli/intents/skills_management/handlers.go` - `handleNavigateData()` correctly passes skill
+- `internal/cli/screens/skills/skill_list.go` - Screen correctly uses `GetSelectedItem()`
+- `internal/cli/intents/skills_management/types.go` - `selectedIndex` field (stale, unused correctly)
+
+## Severity
+
+- [x] High - Wrong skill can be edited or deleted, risking data corruption

--- a/internal/cli/intents/skills_management/helpers.go
+++ b/internal/cli/intents/skills_management/helpers.go
@@ -266,22 +266,21 @@ func (i *Intent) openSearchModal() tea.Cmd {
 }
 
 // openViewDetailModal opens the view detail modal for the selected skill.
+// BUG-016: Uses i.selectedSkill (set by handleNavigateData) instead of
+// indexing i.skills[i.selectedIndex], which was stale and pointed to
+// the wrong skill.
 func (i *Intent) openViewDetailModal() tea.Cmd {
-	if len(i.skills) == 0 || i.selectedIndex >= len(i.skills) {
+	if i.selectedSkill == nil {
 		return nil
 	}
 
-	skill := i.skills[i.selectedIndex]
-	i.selectedSkill = skill
+	skill := i.selectedSkill
 
 	// Get event count for this skill.
 	eventCount := 0
 	if i.eventCounts != nil {
 		eventCount = i.eventCounts[skill.ID]
 	}
-
-	// Last used time could be computed from events but is not currently displayed.
-	// The DetailModal would need to be extended to accept this parameter.
 
 	width, height := i.getTerminalDimensions()
 

--- a/internal/cli/intents/skills_management/intent_test.go
+++ b/internal/cli/intents/skills_management/intent_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/baphled/kariya/internal/cli/behaviors"
 	"github.com/baphled/kariya/internal/cli/intents"
 	"github.com/baphled/kariya/internal/cli/intents/skills_management"
+	"github.com/baphled/kariya/internal/cli/screens"
 	"github.com/baphled/kariya/internal/domain/career"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -208,6 +209,84 @@ var _ = Describe("Intent", func() {
 				result := intent.Result()
 				Expect(result).NotTo(BeNil())
 				Expect(result.Status).To(Equal(intents.Cancelled))
+			})
+		})
+	})
+
+	Describe("Bug Regressions", func() {
+		Describe("BUG-016: view detail modal uses correctly-passed skill, not stale index", func() {
+			var (
+				intent    *skills_management.Intent
+				allSkills []*career.Skill
+			)
+
+			BeforeEach(func() {
+				// Setup 3 skills so index mismatch is detectable.
+				allSkills = []*career.Skill{
+					{ID: "skill-1", Name: "Go", Category: "Programming"},
+					{ID: "skill-2", Name: "Python", Category: "Programming"},
+					{ID: "skill-3", Name: "Rust", Category: "Programming"},
+				}
+				mockRepo.skills = allSkills
+
+				intentCtx := skills_management.NewIntentContext(ctx, mockRepo)
+				intent, _ = skills_management.NewIntent(intentCtx)
+
+				// Init and process the loaded message to populate the intent.
+				cmd := intent.Init()
+				msg := cmd()
+				_ = intent.Update(msg)
+			})
+
+			It("should set selectedSkill to the navigated skill, not the first skill", func() {
+				// Simulate the screen returning a NavigateResult for the 3rd skill.
+				// This is what happens when the user presses Enter on skill-3 in the list.
+				thirdSkill := allSkills[2]
+				navigateResult := &screens.NavigateResult{
+					ResultData: map[string]interface{}{
+						"action": "view",
+						"skill":  thirdSkill,
+					},
+				}
+
+				_ = intent.HandleNavigate(navigateResult)
+
+				// The selected skill must be the 3rd skill, not the 1st.
+				Expect(intent.GetSelectedSkill()).NotTo(BeNil())
+				Expect(intent.GetSelectedSkill().ID).To(Equal("skill-3"))
+				Expect(intent.GetSelectedSkill().Name).To(Equal("Rust"))
+			})
+
+			It("should set selectedSkill correctly for edit action", func() {
+				// Edit action passes skill directly - should not be affected.
+				secondSkill := allSkills[1]
+				navigateResult := &screens.NavigateResult{
+					ResultData: map[string]interface{}{
+						"action": "edit",
+						"skill":  secondSkill,
+					},
+				}
+
+				_ = intent.HandleNavigate(navigateResult)
+
+				Expect(intent.GetSelectedSkill()).NotTo(BeNil())
+				Expect(intent.GetSelectedSkill().ID).To(Equal("skill-2"))
+			})
+
+			It("should set selectedSkill correctly for delete action", func() {
+				// Delete action passes skill directly - should not be affected.
+				thirdSkill := allSkills[2]
+				navigateResult := &screens.NavigateResult{
+					ResultData: map[string]interface{}{
+						"action": "delete",
+						"skill":  thirdSkill,
+					},
+				}
+
+				_ = intent.HandleNavigate(navigateResult)
+
+				Expect(intent.GetSelectedSkill()).NotTo(BeNil())
+				Expect(intent.GetSelectedSkill().ID).To(Equal("skill-3"))
 			})
 		})
 	})


### PR DESCRIPTION
## Summary

Fixes BUG-016: Skill detail modal shows wrong skill when viewing from list. This was a high-severity bug where edit and delete actions could operate on the wrong skill, risking data corruption.

## Root Cause

The `openViewDetailModal()` function was using a stale `i.selectedIndex` to index into `i.skills`, instead of using `i.selectedSkill` which was already correctly set by the navigation handler.

The intent maintained its own `selectedIndex` that was never updated after initial load, while the actual screen's table behavior tracked the real selection.

## Changes

- **helpers.go**: Modified `openViewDetailModal()` to use `i.selectedSkill` instead of `i.skills[i.selectedIndex]`
- **intent_test.go**: Added regression tests for view/edit/delete actions to ensure correct skill is selected
- **bugs/BUG-016-skill-view-wrong-id.md**: Documented the bug, root cause, and fix

## Testing

- ✅ Unit tests added for all three navigation actions (view, edit, delete)
- ✅ Tests verify the correct skill is selected (3rd skill, not 1st)
- ✅ Manual testing confirms detail modal shows the navigated skill

## Related

- Fixes issue where edit/delete from detail modal would operate on wrong skill
- Direct edit/delete from list (pressing `e`/`d`) were not affected, only view-then-edit/delete workflow