### PR TITLE
ci(docs): enforce documentation checks in CI and pre-commit hooks

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -207,8 +207,11 @@ if [ "$SKIP_PATTERN_CHECK" != "1" ]; then
         if [ -n "$STAGED_GO" ]; then
             echo "Running strict pattern checks..."
             if ! bash scripts/check-patterns-strict.sh 2>/dev/null; then
-                echo -e "${YELLOW}⚠️  Pattern violations found. Run 'make check-patterns' for details.${NC}"
-                # Don't block - just warn
+                echo -e "${RED}❌ ERROR: Pattern violations found${NC}"
+                echo ""
+                echo "Run 'make check-patterns' for details."
+                echo "To skip: SKIP_PATTERN_CHECK=1 git commit"
+                exit 1
             fi
         fi
     fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           cache: true
 
       - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
 
       - name: Run golangci-lint
         run: golangci-lint run --timeout=5m

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,62 @@ jobs:
       - name: Run staticcheck
         run: staticcheck ./...
 
+  # Golangci-lint (comprehensive static analysis including doc checks)
+  golangci-lint:
+    name: Golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Install golangci-lint
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+
+      - name: Run golangci-lint
+        run: golangci-lint run --timeout=5m
+
+  # Docblocks enforcement (structured doc comments on exports)
+  docblocks:
+    name: Docblocks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Run docblocks analyzer
+        run: |
+          go build -o ./bin/docblocks ./cmd/docblocks
+          go vet -vettool=./bin/docblocks ./internal/cli/behaviors/... ./internal/cli/intents/... ./tools/analyzers/docblocks/...
+
+  # Intent architecture enforcement
+  architecture:
+    name: Intent Architecture
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Run architecture checks
+        run: bash scripts/check-intent-architecture.sh
+
   # Run tests
   test:
     name: Test
@@ -112,7 +168,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, test, golangci-lint, docblocks, architecture]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -92,6 +94,7 @@ jobs:
           version: v1.64.8
           install-mode: goinstall
           args: --timeout=5m
+          only-new-issues: true
 
   # Docblocks enforcement (structured doc comments on exports)
   docblocks:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.64.8
+          install-mode: goinstall
           args: --timeout=5m
 
   # Docblocks enforcement (structured doc comments on exports)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,11 +86,11 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
-
       - name: Run golangci-lint
-        run: golangci-lint run --timeout=5m
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64.8
+          args: --timeout=5m
 
   # Docblocks enforcement (structured doc comments on exports)
   docblocks:

--- a/Makefile
+++ b/Makefile
@@ -530,7 +530,7 @@ golangci-lint:
 	@echo "Running golangci-lint..."
 	@command -v golangci-lint >/dev/null 2>&1 || { \
 		echo "Installing golangci-lint..."; \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.55.2; \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.64.8; \
 	}
 	@golangci-lint run --timeout=5m
 

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -68,7 +68,7 @@ fi
 # Check and install golangci-lint
 if ! command -v golangci-lint &> /dev/null; then
     echo "Installing golangci-lint..."
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
 fi
 
 # Check npm dependencies

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -65,6 +65,12 @@ if ! command -v gosec &> /dev/null; then
     go install github.com/securego/gosec/v2/cmd/gosec@latest
 fi
 
+# Check and install golangci-lint
+if ! command -v golangci-lint &> /dev/null; then
+    echo "Installing golangci-lint..."
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+fi
+
 # Check npm dependencies
 if [ ! -d "node_modules" ]; then
     echo "Installing npm dependencies..."
@@ -129,6 +135,24 @@ run_check "Build Windows AMD64" \
 # ============================================
 run_check "Gosec Security Scanner" \
     "gosec -no-fail -fmt text ./..."
+
+# ============================================
+# 7. GOLANGCI-LINT (comprehensive static analysis)
+# ============================================
+run_check "Golangci-lint" \
+    "golangci-lint run --timeout=5m"
+
+# ============================================
+# 8. DOCBLOCKS (structured doc comment enforcement)
+# ============================================
+run_check "Docblocks Analyzer" \
+    "go build -o ./bin/docblocks ./cmd/docblocks && go vet -vettool=./bin/docblocks ./internal/cli/behaviors/... ./internal/cli/intents/... ./tools/analyzers/docblocks/..."
+
+# ============================================
+# 9. INTENT ARCHITECTURE (architectural compliance)
+# ============================================
+run_check "Intent Architecture" \
+    "bash scripts/check-intent-architecture.sh"
 
 # ============================================
 # SUMMARY

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -2,173 +2,73 @@
 
 # Install Git Hooks for AI Commit Attribution
 #
-# This script installs git hooks that enforce AI commit attribution rules
+# Configures git to use .git-hooks/ as the hooks directory.
+# This means hooks are tracked in the repo and always in sync.
 
 set -e
 
 echo "================================================"
-echo "🔧 Installing Git Hooks for AI Attribution"
+echo "Installing Git Hooks"
 echo "================================================"
 echo ""
 
-# Colors
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
-# Check if we're in a git repository
 if [ ! -d ".git" ]; then
-    echo "❌ Error: Not in a git repository"
+    echo "Error: Not in a git repository"
     exit 1
 fi
 
-# Create hooks directory if it doesn't exist
-mkdir -p .git/hooks
-
-echo "Installing hooks..."
-echo ""
-
-# Install pre-commit hook
-if [ -f ".git/hooks/pre-commit" ]; then
-    echo -e "${YELLOW}⚠️  pre-commit hook already exists${NC}"
-    echo -n "Overwrite? (y/N): "
-    read -r response
-    if [[ ! "$response" =~ ^[Yy]$ ]]; then
-        echo "Skipping pre-commit..."
-    else
-        cp .git-hooks/pre-commit .git/hooks/pre-commit
-        chmod +x .git/hooks/pre-commit
-        echo -e "${GREEN}✅ Installed pre-commit hook${NC}"
-    fi
-else
-    cp .git-hooks/pre-commit .git/hooks/pre-commit
-    chmod +x .git/hooks/pre-commit
-    echo -e "${GREEN}✅ Installed pre-commit hook${NC}"
+if [ ! -d ".git-hooks" ]; then
+    echo "Error: .git-hooks/ directory not found"
+    exit 1
 fi
 
+git config core.hooksPath .git-hooks
+echo -e "${GREEN}Set core.hooksPath to .git-hooks/${NC}"
 echo ""
 
-# Install prepare-commit-msg hook
-if [ -f ".git/hooks/prepare-commit-msg" ]; then
-    echo -e "${YELLOW}⚠️  prepare-commit-msg hook already exists${NC}"
-    echo -n "Overwrite? (y/N): "
-    read -r response
-    if [[ ! "$response" =~ ^[Yy]$ ]]; then
-        echo "Skipping prepare-commit-msg..."
+REQUIRED_HOOKS=("pre-commit" "commit-msg" "prepare-commit-msg")
+for hook in "${REQUIRED_HOOKS[@]}"; do
+    hook_path=".git-hooks/$hook"
+    if [ -f "$hook_path" ]; then
+        chmod +x "$hook_path"
+        echo -e "  ${GREEN}$hook${NC}"
     else
-        cp .git-hooks/prepare-commit-msg .git/hooks/prepare-commit-msg
-        chmod +x .git/hooks/prepare-commit-msg
-        echo -e "${GREEN}✅ Installed prepare-commit-msg hook${NC}"
+        echo -e "  ${YELLOW}$hook (missing from .git-hooks/)${NC}"
     fi
-else
-    cp .git-hooks/prepare-commit-msg .git/hooks/prepare-commit-msg
-    chmod +x .git/hooks/prepare-commit-msg
-    echo -e "${GREEN}✅ Installed prepare-commit-msg hook${NC}"
-fi
+done
 
-echo ""
-
-# Install commit-msg hook
-if [ -f ".git/hooks/commit-msg" ]; then
-    echo -e "${YELLOW}⚠️  commit-msg hook already exists${NC}"
-    echo -n "Overwrite? (y/N): "
-    read -r response
-    if [[ ! "$response" =~ ^[Yy]$ ]]; then
-        echo "Skipping commit-msg..."
-    else
-        cp .git-hooks/commit-msg .git/hooks/commit-msg
-        chmod +x .git/hooks/commit-msg
-        echo -e "${GREEN}✅ Installed commit-msg hook${NC}"
-    fi
-else
-    cp .git-hooks/commit-msg .git/hooks/commit-msg
-    chmod +x .git/hooks/commit-msg
-    echo -e "${GREEN}✅ Installed commit-msg hook${NC}"
-fi
-
-echo ""
-
-# Install commit-msg-lint hook (optional, requires Node.js)
-if command -v node &> /dev/null && [ -f ".git-hooks/commit-msg-lint" ]; then
-    echo "Installing commitlint hook (optional)..."
-    if [ -f ".git/hooks/commit-msg-lint" ]; then
-        echo -e "${YELLOW}⚠️  commit-msg-lint hook already exists${NC}"
-        echo -n "Overwrite? (y/N): "
-        read -r response
-        if [[ "$response" =~ ^[Yy]$ ]]; then
-            cp .git-hooks/commit-msg-lint .git/hooks/commit-msg-lint
-            chmod +x .git/hooks/commit-msg-lint
-            echo -e "${GREEN}✅ Installed commit-msg-lint hook${NC}"
-        fi
-    else
-        cp .git-hooks/commit-msg-lint .git/hooks/commit-msg-lint
-        chmod +x .git/hooks/commit-msg-lint
-        echo -e "${GREEN}✅ Installed commit-msg-lint hook${NC}"
-    fi
-    echo ""
-else
-    if ! command -v node &> /dev/null; then
-        echo -e "${YELLOW}⚠️  Node.js not found. Skipping commitlint hook.${NC}"
-        echo "   Install Node.js and run 'npm install' to enable commitlint."
-    fi
-    echo ""
-fi
-
-# Install Node.js dependencies if package.json exists
 if [ -f "package.json" ] && command -v npm &> /dev/null; then
+    echo ""
     echo "Installing Node.js dependencies for commitlint..."
     if npm ci 2>/dev/null || npm install 2>/dev/null; then
-        echo -e "${GREEN}✅ Installed Node.js dependencies${NC}"
+        echo -e "${GREEN}Installed Node.js dependencies${NC}"
     else
-        echo -e "${YELLOW}⚠️  Could not install Node.js dependencies${NC}"
+        echo -e "${YELLOW}Could not install Node.js dependencies${NC}"
     fi
-    echo ""
 fi
 
-# Configure git commit template
-echo "Setting up commit message template..."
 if git config commit.template .gitmessage 2>/dev/null; then
-    echo -e "${GREEN}✅ Configured commit template${NC}"
-else
-    echo -e "${YELLOW}⚠️  Could not configure commit template${NC}"
+    echo -e "${GREEN}Configured commit template${NC}"
 fi
 
 echo ""
 echo "================================================"
-echo "✅ Installation Complete"
+echo "Installation Complete"
 echo "================================================"
+echo ""
+echo "Git now uses .git-hooks/ directly (tracked in repo)."
+echo "Hooks stay in sync automatically - no manual copying needed."
 echo ""
 echo "Installed hooks:"
 echo "  - pre-commit: Code quality and TDD enforcement"
 echo "  - prepare-commit-msg: Adds AI attribution reminder"
 echo "  - commit-msg: Validates AI attribution format"
-if command -v node &> /dev/null && [ -f ".git/hooks/commit-msg-lint" ]; then
-    echo "  - commit-msg-lint: Validates conventional commits format"
-fi
 echo ""
-echo "Configured:"
-echo "  - Commit message template (.gitmessage)"
-if [ -d "node_modules" ]; then
-    echo "  - Commitlint (conventional commits validation)"
-fi
-echo ""
-echo -e "${BLUE}Next steps:${NC}"
-echo "1. Read: docs/rules/AI_COMMIT_ATTRIBUTION.md"
-echo "2. When committing AI-generated code, include:"
-echo "   AI-Generated-By: <Assistant> (<Model>)"
-echo "   Reviewed-By: <Your Name>"
-echo "3. Follow conventional commits format:"
-echo "   <type>(<scope>): <subject>"
-echo ""
-echo "To bypass hooks (for emergencies only):"
+echo -e "${BLUE}To bypass hooks (emergencies only):${NC}"
 echo "  git commit --no-verify"
 echo ""
-echo "To uninstall hooks:"
-echo "  rm .git/hooks/prepare-commit-msg"
-echo "  rm .git/hooks/commit-msg"
-if [ -f ".git/hooks/commit-msg-lint" ]; then
-    echo "  rm .git/hooks/commit-msg-lint"
-fi
-echo ""
-

--- a/scripts/verify-hooks.sh
+++ b/scripts/verify-hooks.sh
@@ -2,69 +2,67 @@
 
 # Verify Git Hooks Installation Script
 #
-# Checks that all required git hooks are properly installed and executable
+# Checks that core.hooksPath is set to .git-hooks/ and all required hooks exist.
 
-# Colors
-RED='\033[0;31m'
 GREEN='\033[0;32m'
+RED='\033[0;31m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+NC='\033[0m'
 
-HOOKS_DIR=".git/hooks"
 REQUIRED_HOOKS=("pre-commit" "commit-msg" "prepare-commit-msg")
 MISSING_HOOKS=()
 INVALID_HOOKS=()
 
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "🔍 Git Hooks Verification"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Git Hooks Verification"
 echo ""
 
-# Check if we're in a git repository
 if [ ! -d ".git" ]; then
-    echo -e "${RED}❌ Error: Not in a git repository${NC}"
+    echo -e "${RED}Error: Not in a git repository${NC}"
     exit 1
 fi
 
-# Check each required hook
+HOOKS_PATH=$(git config --get core.hooksPath 2>/dev/null || true)
+
+if [ "$HOOKS_PATH" != ".git-hooks" ]; then
+    echo -e "${YELLOW}core.hooksPath is not set to .git-hooks/${NC}"
+    echo ""
+    echo -e "${BLUE}Run: make install-git-hooks${NC}"
+    echo ""
+    exit 1
+fi
+
+echo -e "core.hooksPath: ${GREEN}.git-hooks/${NC}"
+echo ""
+
 for hook in "${REQUIRED_HOOKS[@]}"; do
-    hook_path="$HOOKS_DIR/$hook"
-    
-    echo -n "Checking $hook: "
-    
+    hook_path=".git-hooks/$hook"
+
+    echo -n "  $hook: "
+
     if [ ! -f "$hook_path" ]; then
-        echo -e "${RED}❌ Missing${NC}"
+        echo -e "${RED}missing${NC}"
         MISSING_HOOKS+=("$hook")
     elif [ ! -x "$hook_path" ]; then
-        echo -e "${YELLOW}⚠️  Not executable${NC}"
+        echo -e "${YELLOW}not executable${NC}"
         INVALID_HOOKS+=("$hook")
+    elif head -1 "$hook_path" | grep -q '^#!/'; then
+        echo -e "${GREEN}ok${NC}"
     else
-        # Verify hook has expected marker (basic validation)
-        # We check for shebang to ensure it's a valid script
-        if head -1 "$hook_path" | grep -q '^#!/'; then
-            echo -e "${GREEN}✅ Installed${NC}"
-        else
-            echo -e "${YELLOW}⚠️  Invalid format${NC}"
-            INVALID_HOOKS+=("$hook")
-        fi
+        echo -e "${YELLOW}invalid format${NC}"
+        INVALID_HOOKS+=("$hook")
     fi
 done
 
 echo ""
 
-# Report results
 if [ ${#MISSING_HOOKS[@]} -eq 0 ] && [ ${#INVALID_HOOKS[@]} -eq 0 ]; then
-    echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-    echo -e "${GREEN}✅ All git hooks are properly installed${NC}"
-    echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${GREEN}All git hooks are properly installed${NC}"
     exit 0
 else
-    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-    echo -e "${RED}❌ Git hooks installation incomplete${NC}"
-    echo -e "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${RED}Git hooks installation incomplete${NC}"
     echo ""
-    
+
     if [ ${#MISSING_HOOKS[@]} -gt 0 ]; then
         echo "Missing hooks:"
         for hook in "${MISSING_HOOKS[@]}"; do
@@ -72,7 +70,7 @@ else
         done
         echo ""
     fi
-    
+
     if [ ${#INVALID_HOOKS[@]} -gt 0 ]; then
         echo "Invalid/non-executable hooks:"
         for hook in "${INVALID_HOOKS[@]}"; do
@@ -80,9 +78,8 @@ else
         done
         echo ""
     fi
-    
-    echo -e "${BLUE}To install hooks, run:${NC}"
-    echo "  make install-git-hooks"
+
+    echo -e "${BLUE}Run: make install-git-hooks${NC}"
     echo ""
     exit 1
 fi


### PR DESCRIPTION
## Summary

- Add `golangci-lint`, `docblocks` analyzer, and `intent architecture` jobs to GitHub Actions CI pipeline (`.github/workflows/ci.yml`) so documentation rules are validated on every push/PR
- Mirror the same three checks in `scripts/ci-local.sh` for local CI parity
- Make `check-patterns-strict` blocking in the pre-commit hook (was warn-only), enforcing documentation requirements for new intents, UIKit components, and behaviors
- Replace fragile hook copy approach (`cp .git-hooks/* .git/hooks/`) with `git config core.hooksPath .git-hooks`, so hooks are always in sync with the repo

## Motivation

Documentation enforcement was defined in AGENTS.md but not actually enforced by CI or hooks. The `golangci-lint` (godox, godot, revive), `check-docblocks`, and `check-intent-architecture` checks only ran if developers remembered to call `make check-compliance` manually. The installed pre-commit hook was also stale relative to the `.git-hooks/` source.

## Changes

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | 3 new CI jobs: `golangci-lint`, `docblocks`, `architecture`; build depends on all |
| `scripts/ci-local.sh` | Added golangci-lint tool install + 3 new `run_check` steps (7, 8, 9) |
| `.git-hooks/pre-commit` | `check-patterns-strict` now exits 1 on violations (skippable with `SKIP_PATTERN_CHECK=1`) |
| `scripts/install-git-hooks.sh` | Replaced 175-line copy script with `git config core.hooksPath .git-hooks` |
| `scripts/verify-hooks.sh` | Now validates `core.hooksPath` is set correctly instead of checking `.git/hooks/` |