### PR TITLE
feat: enhance skill categorization coverage

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -19,6 +19,7 @@ import (
 	careermemory "github.com/baphled/kariya/internal/repository/career/memory"
 	careersql "github.com/baphled/kariya/internal/repository/career/sql"
 	careerservice "github.com/baphled/kariya/internal/service/career"
+	"github.com/baphled/kariya/internal/service/career/technology"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -33,19 +34,20 @@ func main() {
 func run(args []string, out io.Writer, errOut io.Writer) int {
 	// Parse CLI flags
 	var (
-		showVersion  = false
-		showHelp     = false
-		dbPath       = ""
-		mode         = ""
-		listEvents   = false
-		inMemory     = false
-		importPath   = ""
-		importSkip   = false
-		reviewFacts  = false
-		detectBursts = false
-		extractFacts = false
-		showBursts   = false
-		showFacts    = false
+		showVersion        = false
+		showHelp           = false
+		dbPath             = ""
+		mode               = ""
+		listEvents         = false
+		inMemory           = false
+		importPath         = ""
+		importSkip         = false
+		reviewFacts        = false
+		detectBursts       = false
+		extractFacts       = false
+		showBursts         = false
+		showFacts          = false
+		recategorizeSkills = false
 	)
 
 	// Parse command-line arguments
@@ -92,6 +94,8 @@ func run(args []string, out io.Writer, errOut io.Writer) int {
 			showBursts = true
 		case "--show-facts":
 			showFacts = true
+		case "--recategorize-skills":
+			recategorizeSkills = true
 		}
 	}
 
@@ -181,6 +185,10 @@ func run(args []string, out io.Writer, errOut io.Writer) int {
 
 	if showFacts {
 		return handleShowFacts(svc, out, errOut)
+	}
+
+	if recategorizeSkills {
+		return handleRecategorizeSkills(svc, out, errOut)
 	}
 
 	// Handle non-interactive import
@@ -447,6 +455,48 @@ func handleShowFacts(svc *careerservice.Service, out io.Writer, errOut io.Writer
 	return 0
 }
 
+// handleRecategorizeSkills updates existing skills using the keyword dictionary.
+func handleRecategorizeSkills(svc *careerservice.Service, out io.Writer, errOut io.Writer) int {
+	ctx := context.Background()
+
+	skillRepo := svc.GetSkillRepository()
+	if skillRepo == nil {
+		fmt.Fprintf(errOut, "Error: Skill repository not configured\n")
+		return 1
+	}
+
+	result, err := technology.RecategorizeSkills(ctx, skillRepo)
+	if err != nil {
+		fmt.Fprintf(errOut, "Error recategorizing skills: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(out, "Recategorized %d skills", result.Updated)
+	if len(result.ByCategory) > 0 {
+		categories := make([]string, 0, len(result.ByCategory))
+		for cat := range result.ByCategory {
+			categories = append(categories, cat)
+		}
+		sort.Strings(categories)
+
+		parts := make([]string, 0, len(categories))
+		for _, cat := range categories {
+			parts = append(parts, fmt.Sprintf("%d %s", result.ByCategory[cat], cat))
+		}
+		fmt.Fprintf(out, " (%s)", strings.Join(parts, ", "))
+	}
+	fmt.Fprintf(out, "\n")
+
+	if result.NoMatch > 0 {
+		fmt.Fprintf(out, "Skipped %d skills with no keyword match\n", result.NoMatch)
+	}
+	if result.Skipped > 0 {
+		fmt.Fprintf(out, "Skipped %d skills already correctly categorized\n", result.Skipped)
+	}
+
+	return 0
+}
+
 // handleNonInteractiveImport performs import without showing the interactive UI.
 func handleNonInteractiveImport(filePath string, _ bool, _ bool, svc *careerservice.Service, out io.Writer, errOut io.Writer) int {
 	if _, err := os.Stat(filePath); err != nil {
@@ -573,6 +623,7 @@ func printHelpTo(out io.Writer) {
 	fmt.Fprintln(out, "  --extract-facts            Re-run fact extraction on all events")
 	fmt.Fprintln(out, "  --show-bursts              Display all existing bursts")
 	fmt.Fprintln(out, "  --show-facts               Display all existing facts")
+	fmt.Fprintln(out, "  --recategorize-skills      Re-categorize existing skills using keyword dictionary")
 	fmt.Fprintln(out, "\nExamples:")
 	fmt.Fprintln(out, "  kariya                                    # Start with default database")
 	fmt.Fprintln(out, "  kariya --db ./events.db                  # Use custom database path")
@@ -585,7 +636,8 @@ func printHelpTo(out io.Writer) {
 	fmt.Fprintln(out, "  kariya --detect-bursts                   # Re-detect all bursts")
 	fmt.Fprintln(out, "  kariya --extract-facts                   # Re-extract all facts")
 	fmt.Fprintln(out, "  kariya --show-bursts                     # List all bursts")
-	fmt.Fprintln(out, "  kariya --show-facts                      # List all facts")
+	fmt.Fprintln(out, "  kariya --show-facts                     # List all facts")
+	fmt.Fprintln(out, "  kariya --recategorize-skills            # Re-categorize skills")
 	fmt.Fprintln(out, "  kariya --version                         # Show version")
 	fmt.Fprintln(out, "\nCSV File Format:")
 	fmt.Fprintln(out, "  The CSV file should have the following columns (in any order):")

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -278,4 +278,29 @@ Mentored junior engineers on best practices,2025-12-22,TechCorp,Training,mentori
 			}
 		})
 	})
+
+	Context("Recategorize Skills Flag", func() {
+		It("should show --recategorize-skills flag in help", func() {
+			var buf, errBuf bytes.Buffer
+			run([]string{"--help"}, &buf, &errBuf)
+
+			Expect(buf.String()).To(ContainSubstring("--recategorize-skills"))
+			Expect(buf.String()).To(ContainSubstring("Re-categorize existing skills"))
+		})
+
+		It("should handle --recategorize-skills with empty database", func() {
+			var buf, errBuf bytes.Buffer
+			exitCode := run([]string{"--in-memory", "--recategorize-skills"}, &buf, &errBuf)
+
+			Expect(exitCode).To(Equal(0))
+			Expect(buf.String()).To(ContainSubstring("Recategorized 0 skills"))
+		})
+
+		It("should show recategorize example in help", func() {
+			var buf, errBuf bytes.Buffer
+			run([]string{"--help"}, &buf, &errBuf)
+
+			Expect(buf.String()).To(ContainSubstring("kariya --recategorize-skills"))
+		})
+	})
 })

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -324,25 +324,35 @@ const (
 	// SkillCategoryTooling groups developer productivity tools such as
 	// editors, linters, profilers, build systems, and version control.
 	SkillCategoryTooling SkillCategory = "tooling"
-	// SkillCategoryTesting groups testing frameworks and quality assurance
-	// tools such as Jest, Pytest, Selenium, Cypress, and Ginkgo.
+	// SkillCategoryTesting groups quality assurance technologies such as
+	// test frameworks, assertion libraries, and code coverage tools.
 	SkillCategoryTesting SkillCategory = "testing"
 	// SkillCategoryData groups data engineering technologies such as
-	// Apache Spark, Airflow, Snowflake, dbt, and ETL pipelines.
+	// ETL pipelines, analytics platforms, and business intelligence tools.
 	SkillCategoryData SkillCategory = "data"
-	// SkillCategoryML groups machine learning and AI technologies such as
-	// TensorFlow, PyTorch, scikit-learn, and OpenAI integrations.
+	// SkillCategoryML groups machine learning and artificial intelligence
+	// technologies such as TensorFlow, PyTorch, and LLM tooling.
 	SkillCategoryML SkillCategory = "ml"
-	// SkillCategoryMonitoring groups observability and monitoring tools
-	// such as Prometheus, Grafana, Splunk, Sentry, and PagerDuty.
+	// SkillCategoryMonitoring groups observability technologies such as
+	// Prometheus, Grafana, ELK stack, and alerting systems.
 	SkillCategoryMonitoring SkillCategory = "monitoring"
+	// SkillCategoryArchitecture groups system design patterns and
+	// architectural concepts such as microservices, DDD, and CQRS.
+	SkillCategoryArchitecture SkillCategory = "architecture"
+	// SkillCategorySecurity groups security and compliance technologies
+	// such as OAuth, TLS, encryption, and access control systems.
+	SkillCategorySecurity SkillCategory = "security"
+	// SkillCategoryPractices groups engineering methodologies and practices
+	// such as Agile, TDD, code review, and incident management.
+	SkillCategoryPractices SkillCategory = "practices"
 	// SkillCategoryOther is a catch-all for skills that do not fit neatly
 	// into the predefined categories above.
 	SkillCategoryOther SkillCategory = "other"
 )
 
 // AllSkillCategories returns every defined SkillCategory value in declaration
-// order. Use this for validation checks and exhaustive iterations.
+// order. The returned slice is the single source of truth for all valid skill
+// categories and is used for validation, form dropdowns, and test assertions.
 func AllSkillCategories() []SkillCategory {
 	return []SkillCategory{
 		SkillCategoryBackend,
@@ -356,6 +366,9 @@ func AllSkillCategories() []SkillCategory {
 		SkillCategoryData,
 		SkillCategoryML,
 		SkillCategoryMonitoring,
+		SkillCategoryArchitecture,
+		SkillCategorySecurity,
+		SkillCategoryPractices,
 		SkillCategoryOther,
 	}
 }
@@ -379,6 +392,19 @@ func IsValidSkillCategory(s string) bool {
 	return false
 }
 
+// SkillCategoryStrings returns a string slice of all skill category values
+// in the same order as AllSkillCategories. This is useful for building
+// dynamic error messages and validation feedback.
+func SkillCategoryStrings() []string {
+	cats := AllSkillCategories()
+	result := make([]string, len(cats))
+	for i, c := range cats {
+		result[i] = string(c)
+	}
+	return result
+}
+
+>>>>>>> 49bc64e4 (feat(domain): add architecture, security, practices skill categories)
 // SectionType identifies the kind of content block within a generated CV. The
 // CV renderer uses it to apply the correct layout, ordering, and formatting
 // rules for each block.

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -404,7 +404,6 @@ func SkillCategoryStrings() []string {
 	return result
 }
 
->>>>>>> 49bc64e4 (feat(domain): add architecture, security, practices skill categories)
 // SectionType identifies the kind of content block within a generated CV. The
 // CV renderer uses it to apply the correct layout, ordering, and formatting
 // rules for each block.

--- a/internal/constants/constants_test.go
+++ b/internal/constants/constants_test.go
@@ -203,9 +203,9 @@ var _ = Describe("Constants", func() {
 
 	Describe("SkillCategory", func() {
 		Describe("AllSkillCategories", func() {
-			It("returns all 12 defined skill categories", func() {
+			It("returns all 15 defined skill categories", func() {
 				categories := constants.AllSkillCategories()
-				Expect(categories).To(HaveLen(12))
+				Expect(categories).To(HaveLen(15))
 				Expect(categories).To(ContainElements(
 					constants.SkillCategoryBackend,
 					constants.SkillCategoryFrontend,
@@ -218,15 +218,18 @@ var _ = Describe("Constants", func() {
 					constants.SkillCategoryData,
 					constants.SkillCategoryML,
 					constants.SkillCategoryMonitoring,
+					constants.SkillCategoryArchitecture,
+					constants.SkillCategorySecurity,
+					constants.SkillCategoryPractices,
 					constants.SkillCategoryOther,
 				))
 			})
 		})
 
 		Describe("SuggestedSkillCategories", func() {
-			It("returns all skill categories for form dropdowns", func() {
+			It("returns all 15 skill categories for form dropdowns", func() {
 				categories := constants.SuggestedSkillCategories()
-				Expect(categories).To(HaveLen(12))
+				Expect(categories).To(HaveLen(15))
 				Expect(categories).To(ContainElements(
 					constants.SkillCategoryBackend,
 					constants.SkillCategoryFrontend,
@@ -239,13 +242,20 @@ var _ = Describe("Constants", func() {
 					constants.SkillCategoryData,
 					constants.SkillCategoryML,
 					constants.SkillCategoryMonitoring,
+					constants.SkillCategoryArchitecture,
+					constants.SkillCategorySecurity,
+					constants.SkillCategoryPractices,
 					constants.SkillCategoryOther,
 				))
+			})
+
+			It("delegates to AllSkillCategories", func() {
+				Expect(constants.SuggestedSkillCategories()).To(Equal(constants.AllSkillCategories()))
 			})
 		})
 
 		Describe("IsValidSkillCategory", func() {
-			It("returns true for all canonical skill categories", func() {
+			It("returns true for all canonical categories", func() {
 				Expect(constants.IsValidSkillCategory("backend")).To(BeTrue())
 				Expect(constants.IsValidSkillCategory("frontend")).To(BeTrue())
 				Expect(constants.IsValidSkillCategory("devops")).To(BeTrue())
@@ -257,6 +267,9 @@ var _ = Describe("Constants", func() {
 				Expect(constants.IsValidSkillCategory("data")).To(BeTrue())
 				Expect(constants.IsValidSkillCategory("ml")).To(BeTrue())
 				Expect(constants.IsValidSkillCategory("monitoring")).To(BeTrue())
+				Expect(constants.IsValidSkillCategory("architecture")).To(BeTrue())
+				Expect(constants.IsValidSkillCategory("security")).To(BeTrue())
+				Expect(constants.IsValidSkillCategory("practices")).To(BeTrue())
 				Expect(constants.IsValidSkillCategory("other")).To(BeTrue())
 			})
 
@@ -265,11 +278,26 @@ var _ = Describe("Constants", func() {
 				Expect(constants.IsValidSkillCategory("")).To(BeFalse())
 				Expect(constants.IsValidSkillCategory("BACKEND")).To(BeFalse())
 			})
+		})
 
-			It("returns false for categories that were merged into existing ones", func() {
-				Expect(constants.IsValidSkillCategory("build")).To(BeFalse())
-				Expect(constants.IsValidSkillCategory("documentation")).To(BeFalse())
-				Expect(constants.IsValidSkillCategory("os")).To(BeFalse())
+		Describe("SkillCategoryStrings", func() {
+			It("returns string slice of all 15 categories", func() {
+				strings := constants.SkillCategoryStrings()
+				Expect(strings).To(HaveLen(15))
+				Expect(strings).To(ContainElements(
+					"backend", "frontend", "devops", "database", "cloud",
+					"mobile", "tooling", "testing", "data", "ml",
+					"monitoring", "architecture", "security", "practices", "other",
+				))
+			})
+
+			It("returns strings in same order as AllSkillCategories", func() {
+				categories := constants.AllSkillCategories()
+				strings := constants.SkillCategoryStrings()
+				Expect(strings).To(HaveLen(len(categories)))
+				for i, cat := range categories {
+					Expect(strings[i]).To(Equal(string(cat)))
+				}
 			})
 		})
 	})

--- a/internal/service/career/cv/profile_inference.go
+++ b/internal/service/career/cv/profile_inference.go
@@ -96,9 +96,15 @@ func (s *ProfileInferenceService) InferCoreStrengths(
 		}
 	}
 
-	// Add skill-based strength if we have backend skills
+	// Add skill-based strengths for key categories
 	if s.hasExpertiseIn(skills, string(constants.SkillCategoryBackend)) {
 		strengths = append(strengths, "Backend and systems engineering expertise")
+	}
+	if s.hasExpertiseIn(skills, string(constants.SkillCategoryArchitecture)) {
+		strengths = append(strengths, "System design and architecture expertise")
+	}
+	if s.hasExpertiseIn(skills, string(constants.SkillCategorySecurity)) {
+		strengths = append(strengths, "Security and compliance expertise")
 	}
 
 	// Ensure we have at least 3 strengths
@@ -203,7 +209,9 @@ func (s *ProfileInferenceService) InferTechnologies(
 		case string(constants.SkillCategoryDatabase),
 			string(constants.SkillCategoryDevOps),
 			string(constants.SkillCategoryCloud),
-			string(constants.SkillCategoryTooling):
+			string(constants.SkillCategoryTooling),
+			string(constants.SkillCategoryArchitecture),
+			string(constants.SkillCategorySecurity):
 			systems = append(systems, skill.Name)
 		}
 	}

--- a/internal/service/career/cv/profile_inference_test.go
+++ b/internal/service/career/cv/profile_inference_test.go
@@ -109,6 +109,50 @@ var _ = Describe("ProfileInferenceService", func() {
 			})
 		})
 
+		Context("when skills indicate architecture expertise", func() {
+			BeforeEach(func() {
+				skills = []*career.Skill{
+					fixtures.SkillWith("skill-1", "Microservices", "architecture", "expert"),
+					fixtures.SkillWith("skill-2", "DDD", "architecture", "advanced"),
+				}
+			})
+
+			It("should infer architecture-related core strength", func() {
+				strengths := service.InferCoreStrengths(events, facts, skills)
+				Expect(strengths).NotTo(BeEmpty())
+				hasArchStrength := false
+				for _, s := range strengths {
+					if ContainsAny(s, []string{"architecture", "system design"}) {
+						hasArchStrength = true
+						break
+					}
+				}
+				Expect(hasArchStrength).To(BeTrue(), "Should have architecture-related strength")
+			})
+		})
+
+		Context("when skills indicate security expertise", func() {
+			BeforeEach(func() {
+				skills = []*career.Skill{
+					fixtures.SkillWith("skill-1", "OAuth", "security", "expert"),
+					fixtures.SkillWith("skill-2", "TLS", "security", "advanced"),
+				}
+			})
+
+			It("should infer security-related core strength", func() {
+				strengths := service.InferCoreStrengths(events, facts, skills)
+				Expect(strengths).NotTo(BeEmpty())
+				hasSecurityStrength := false
+				for _, s := range strengths {
+					if ContainsAny(s, []string{"security", "compliance"}) {
+						hasSecurityStrength = true
+						break
+					}
+				}
+				Expect(hasSecurityStrength).To(BeTrue(), "Should have security-related strength")
+			})
+		})
+
 		Context("when no career data is provided", func() {
 			It("should return generic core strengths", func() {
 				strengths := service.InferCoreStrengths(nil, nil, nil)
@@ -261,6 +305,36 @@ var _ = Describe("ProfileInferenceService", func() {
 			It("should extract systems/database from skills", func() {
 				result := service.InferTechnologies(events, skills)
 				Expect(result.Systems).To(ContainElement("PostgreSQL"))
+			})
+		})
+
+		Context("when skills include architecture category", func() {
+			BeforeEach(func() {
+				skills = []*career.Skill{
+					fixtures.SkillWith("skill-1", "Microservices", "architecture", "expert"),
+					fixtures.SkillWith("skill-2", "CQRS", "architecture", "advanced"),
+				}
+			})
+
+			It("should route architecture skills to systems", func() {
+				result := service.InferTechnologies(events, skills)
+				Expect(result.Systems).To(ContainElement("Microservices"))
+				Expect(result.Systems).To(ContainElement("CQRS"))
+			})
+		})
+
+		Context("when skills include security category", func() {
+			BeforeEach(func() {
+				skills = []*career.Skill{
+					fixtures.SkillWith("skill-1", "OAuth", "security", "advanced"),
+					fixtures.SkillWith("skill-2", "TLS", "security", "intermediate"),
+				}
+			})
+
+			It("should route security skills to systems", func() {
+				result := service.InferTechnologies(events, skills)
+				Expect(result.Systems).To(ContainElement("OAuth"))
+				Expect(result.Systems).To(ContainElement("TLS"))
 			})
 		})
 

--- a/internal/service/career/skillinference/detector_test.go
+++ b/internal/service/career/skillinference/detector_test.go
@@ -30,8 +30,8 @@ var _ = Describe("DefaultSkillInferenceService", func() {
 			result, err := service.InferSkillsFromEvents(ctx, events)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Suggestions).To(HaveLen(1))
-			Expect(result.Suggestions[0].Name).To(Equal("Go"))
+			names := extractNames(result.Suggestions)
+			Expect(names).To(ContainElements("Go"))
 		})
 
 		It("should NOT match 'go' in 'goal'", func() {
@@ -97,8 +97,8 @@ var _ = Describe("DefaultSkillInferenceService", func() {
 			result, err := service.InferSkillsFromEvents(ctx, events)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Suggestions).NotTo(BeEmpty())
-			Expect(result.Suggestions[0].Name).To(Equal("Go"))
+			names := extractNames(result.Suggestions)
+			Expect(names).To(ContainElements("Go"))
 		})
 
 		It("should match 'GO' (all caps)", func() {

--- a/internal/service/career/skillinference/detector_test.go
+++ b/internal/service/career/skillinference/detector_test.go
@@ -85,8 +85,8 @@ var _ = Describe("DefaultSkillInferenceService", func() {
 			result, err := service.InferSkillsFromEvents(ctx, events)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Suggestions).NotTo(BeEmpty())
-			Expect(result.Suggestions[0].Name).To(Equal("Go"))
+			names := extractNames(result.Suggestions)
+			Expect(names).To(ContainElements("Go"))
 		})
 
 		It("should match 'go' (lowercase)", func() {

--- a/internal/service/career/technology/keywords.go
+++ b/internal/service/career/technology/keywords.go
@@ -1,351 +1,421 @@
+// Package technology provides skill extraction, focus area analysis, and
+// keyword-based categorization for career technologies.
 package technology
 
 import "strings"
 
-// TechnologyKeyword maps a search keyword to its canonical skill.
-// Keywords are lowercase for case-insensitive matching.
-// Skills use canonical names for display (e.g., "Go", "PostgreSQL").
-type TechnologyKeyword struct { //nolint:revive // renaming would break all consumers of this type
-	Keyword  string // Lowercase search term for matching (e.g., "golang")
-	Skill    string // Canonical skill name for display (e.g., "Go")
-	Category string // Skill category: backend, frontend, database, devops, cloud, mobile, tooling, testing, ml, data, monitoring, other
+// TechnologyKeyword maps a lowercase search keyword to a display-friendly
+// skill name and its canonical category. The keyword is used for
+// case-insensitive matching against user-entered skill names.
+type TechnologyKeyword struct {
+	Keyword  string
+	Skill    string
+	Category string
 }
 
-// technologyKeywords is the master dictionary organized by category.
-// This comprehensive list covers ~224 keywords across 14 categories.
-var technologyKeywords = []TechnologyKeyword{
-	// ========================================
-	// BACKEND LANGUAGES & FRAMEWORKS (28)
-	// ========================================
-	{"go", "Go", "backend"},
-	{"golang", "Go", "backend"},
-	{"python", "Python", "backend"},
-	{"ruby", "Ruby", "backend"},
-	{"rails", "Ruby on Rails", "backend"},
-	{"ruby on rails", "Ruby on Rails", "backend"},
-	{"java", "Java", "backend"},
-	{"spring", "Spring", "backend"},
-	{"spring boot", "Spring Boot", "backend"},
-	{"scala", "Scala", "backend"},
-	{"rust", "Rust", "backend"},
-	{"c#", "C#", "backend"},
-	{"csharp", "C#", "backend"},
-	{".net", ".NET", "backend"},
-	{"dotnet", ".NET", "backend"},
-	{"node", "Node.js", "backend"},
-	{"nodejs", "Node.js", "backend"},
-	{"node.js", "Node.js", "backend"},
-	{"express", "Express.js", "backend"},
-	{"expressjs", "Express.js", "backend"},
-	{"php", "PHP", "backend"},
-	{"laravel", "Laravel", "backend"},
-	{"symfony", "Symfony", "backend"},
-	{"elixir", "Elixir", "backend"},
-	{"phoenix", "Phoenix", "backend"},
+// TechnologyKeywords is the canonical keyword dictionary mapping technology
+// names to their skill categories. Each entry has a lowercase keyword for
+// matching, a display-friendly skill name, and a category from
+// constants.AllSkillCategories().
+var TechnologyKeywords = []TechnologyKeyword{
 
-	// ========================================
-	// FRONTEND FRAMEWORKS & LIBRARIES (35)
-	// ========================================
-	{"react", "React", "frontend"},
-	{"reactjs", "React", "frontend"},
-	{"react.js", "React", "frontend"},
-	{"vue", "Vue.js", "frontend"},
-	{"vuejs", "Vue.js", "frontend"},
-	{"vue.js", "Vue.js", "frontend"},
-	{"angular", "Angular", "frontend"},
-	{"angularjs", "Angular", "frontend"},
-	{"svelte", "Svelte", "frontend"},
-	{"typescript", "TypeScript", "frontend"},
-	{"javascript", "JavaScript", "frontend"},
-	{"nextjs", "Next.js", "frontend"},
-	{"next.js", "Next.js", "frontend"},
-	{"nuxt", "Nuxt.js", "frontend"},
-	{"gatsby", "Gatsby", "frontend"},
-	{"ember", "Ember.js", "frontend"},
-	{"backbone", "Backbone.js", "frontend"},
-	{"jquery", "jQuery", "frontend"},
-	{"html", "HTML", "frontend"},
-	{"css", "CSS", "frontend"},
-	{"tailwind", "Tailwind CSS", "frontend"},
-	{"tailwindcss", "Tailwind CSS", "frontend"},
-	{"bootstrap", "Bootstrap", "frontend"},
-	{"sass", "Sass", "frontend"},
-	{"scss", "Sass", "frontend"},
-	{"less", "Less", "frontend"},
-	{"webpack", "Webpack", "frontend"},
-	{"vite", "Vite", "frontend"},
-	{"rollup", "Rollup", "frontend"},
-	{"parcel", "Parcel", "frontend"},
+	// --- backend (35) ---
+	{Keyword: "go", Skill: "Go", Category: "backend"},
+	{Keyword: "golang", Skill: "Go", Category: "backend"},
+	{Keyword: "ruby", Skill: "Ruby", Category: "backend"},
+	{Keyword: "python", Skill: "Python", Category: "backend"},
+	{Keyword: "java", Skill: "Java", Category: "backend"},
+	{Keyword: "c#", Skill: "C#", Category: "backend"},
+	{Keyword: "c", Skill: "C", Category: "backend"},
+	{Keyword: "c++", Skill: "C++", Category: "backend"},
+	{Keyword: "rust", Skill: "Rust", Category: "backend"},
+	{Keyword: "scala", Skill: "Scala", Category: "backend"},
+	{Keyword: "kotlin", Skill: "Kotlin", Category: "backend"},
+	{Keyword: "elixir", Skill: "Elixir", Category: "backend"},
+	{Keyword: "erlang", Skill: "Erlang", Category: "backend"},
+	{Keyword: "haskell", Skill: "Haskell", Category: "backend"},
+	{Keyword: "clojure", Skill: "Clojure", Category: "backend"},
+	{Keyword: "php", Skill: "PHP", Category: "backend"},
+	{Keyword: "perl", Skill: "Perl", Category: "backend"},
+	{Keyword: "node.js", Skill: "Node.js", Category: "backend"},
+	{Keyword: "nodejs", Skill: "Node.js", Category: "backend"},
+	{Keyword: "express", Skill: "Express", Category: "backend"},
+	{Keyword: "django", Skill: "Django", Category: "backend"},
+	{Keyword: "flask", Skill: "Flask", Category: "backend"},
+	{Keyword: "rails", Skill: "Rails", Category: "backend"},
+	{Keyword: "ruby on rails", Skill: "Ruby on Rails", Category: "backend"},
+	{Keyword: "spring", Skill: "Spring", Category: "backend"},
+	{Keyword: "spring boot", Skill: "Spring Boot", Category: "backend"},
+	{Keyword: "grpc", Skill: "gRPC", Category: "backend"},
+	{Keyword: "graphql", Skill: "GraphQL", Category: "backend"},
+	{Keyword: "rest", Skill: "REST", Category: "backend"},
+	{Keyword: "api design", Skill: "API Design", Category: "backend"},
+	{Keyword: "coffeescript", Skill: "CoffeeScript", Category: "backend"},
+	{Keyword: "zend", Skill: "Zend", Category: "backend"},
+	{Keyword: "wordpress", Skill: "WordPress", Category: "backend"},
+	{Keyword: "sidekiq", Skill: "Sidekiq", Category: "backend"},
+	{Keyword: "ajax", Skill: "AJAX", Category: "backend"},
+	{Keyword: "soap", Skill: "SOAP", Category: "backend"},
+	{Keyword: "api", Skill: "API", Category: "backend"},
+	{Keyword: "websockets", Skill: "WebSockets", Category: "backend"},
+	{Keyword: "sinatra", Skill: "Sinatra", Category: "backend"},
+	{Keyword: "laravel", Skill: "Laravel", Category: "backend"},
+	{Keyword: "fastapi", Skill: "FastAPI", Category: "backend"},
+	{Keyword: ".net", Skill: ".NET", Category: "backend"},
+	{Keyword: "dotnet", Skill: ".NET", Category: "backend"},
+	{Keyword: "swift", Skill: "Swift", Category: "backend"},
+	{Keyword: "objective-c", Skill: "Objective-C", Category: "backend"},
+	{Keyword: "groovy", Skill: "Groovy", Category: "backend"},
+	{Keyword: "lua", Skill: "Lua", Category: "backend"},
+	{Keyword: "r", Skill: "R", Category: "backend"},
+	{Keyword: "dart", Skill: "Dart", Category: "backend"},
+	{Keyword: "f#", Skill: "F#", Category: "backend"},
+	{Keyword: "ocaml", Skill: "OCaml", Category: "backend"},
+	{Keyword: "zig", Skill: "Zig", Category: "backend"},
+	{Keyword: "delphi", Skill: "Delphi", Category: "backend"},
+	{Keyword: "asp.net", Skill: "ASP.NET", Category: "backend"},
+	{Keyword: "nestjs", Skill: "NestJS", Category: "backend"},
 
-	// ========================================
-	// DATABASES (19)
-	// ========================================
-	{"postgresql", "PostgreSQL", "database"},
-	{"postgres", "PostgreSQL", "database"},
-	{"mysql", "MySQL", "database"},
-	{"mariadb", "MariaDB", "database"},
-	{"mongodb", "MongoDB", "database"},
-	{"mongo", "MongoDB", "database"},
-	{"redis", "Redis", "database"},
-	{"elasticsearch", "Elasticsearch", "database"},
-	{"elastic", "Elasticsearch", "database"},
-	{"dynamodb", "DynamoDB", "database"},
-	{"cassandra", "Cassandra", "database"},
-	{"couchdb", "CouchDB", "database"},
-	{"sqlite", "SQLite", "database"},
-	{"oracle", "Oracle DB", "database"},
-	{"sql server", "SQL Server", "database"},
-	{"mssql", "SQL Server", "database"},
-	{"neo4j", "Neo4j", "database"},
-	{"influxdb", "InfluxDB", "database"},
-	{"timescaledb", "TimescaleDB", "database"},
+	// --- frontend (25) ---
+	{Keyword: "javascript", Skill: "JavaScript", Category: "frontend"},
+	{Keyword: "typescript", Skill: "TypeScript", Category: "frontend"},
+	{Keyword: "react", Skill: "React", Category: "frontend"},
+	{Keyword: "reactjs", Skill: "React", Category: "frontend"},
+	{Keyword: "react.js", Skill: "React", Category: "frontend"},
+	{Keyword: "angular", Skill: "Angular", Category: "frontend"},
+	{Keyword: "vue", Skill: "Vue", Category: "frontend"},
+	{Keyword: "vue.js", Skill: "Vue.js", Category: "frontend"},
+	{Keyword: "svelte", Skill: "Svelte", Category: "frontend"},
+	{Keyword: "next.js", Skill: "Next.js", Category: "frontend"},
+	{Keyword: "nextjs", Skill: "Next.js", Category: "frontend"},
+	{Keyword: "html", Skill: "HTML", Category: "frontend"},
+	{Keyword: "css", Skill: "CSS", Category: "frontend"},
+	{Keyword: "sass", Skill: "Sass", Category: "frontend"},
+	{Keyword: "tailwind", Skill: "Tailwind CSS", Category: "frontend"},
+	{Keyword: "webpack", Skill: "Webpack", Category: "frontend"},
+	{Keyword: "jquery", Skill: "jQuery", Category: "frontend"},
+	{Keyword: "redux", Skill: "Redux", Category: "frontend"},
+	{Keyword: "backbonejs", Skill: "Backbone.js", Category: "frontend"},
+	{Keyword: "backbone.js", Skill: "Backbone.js", Category: "frontend"},
+	{Keyword: "responsive design", Skill: "Responsive Design", Category: "frontend"},
+	{Keyword: "accessibility", Skill: "Accessibility", Category: "frontend"},
+	{Keyword: "storybook", Skill: "Storybook", Category: "frontend"},
+	{Keyword: "seo", Skill: "SEO", Category: "frontend"},
+	{Keyword: "design systems", Skill: "Design Systems", Category: "frontend"},
+	{Keyword: "visual design", Skill: "Visual Design", Category: "frontend"},
+	{Keyword: "ember", Skill: "Ember.js", Category: "frontend"},
+	{Keyword: "ember.js", Skill: "Ember.js", Category: "frontend"},
+	{Keyword: "bootstrap", Skill: "Bootstrap", Category: "frontend"},
+	{Keyword: "material ui", Skill: "Material UI", Category: "frontend"},
+	{Keyword: "d3.js", Skill: "D3.js", Category: "frontend"},
+	{Keyword: "gatsby", Skill: "Gatsby", Category: "frontend"},
+	{Keyword: "nuxt", Skill: "Nuxt.js", Category: "frontend"},
+	{Keyword: "nuxt.js", Skill: "Nuxt.js", Category: "frontend"},
+	{Keyword: "less", Skill: "Less", Category: "frontend"},
+	{Keyword: "styled-components", Skill: "Styled Components", Category: "frontend"},
 
-	// ========================================
-	// DEVOPS & INFRASTRUCTURE (24)
-	// ========================================
-	{"kubernetes", "Kubernetes", "devops"},
-	{"k8s", "Kubernetes", "devops"},
-	{"docker", "Docker", "devops"},
-	{"terraform", "Terraform", "devops"},
-	{"ansible", "Ansible", "devops"},
-	{"puppet", "Puppet", "devops"},
-	{"chef", "Chef", "devops"},
-	{"jenkins", "Jenkins", "devops"},
-	{"circleci", "CircleCI", "devops"},
-	{"circle ci", "CircleCI", "devops"},
-	{"github actions", "GitHub Actions", "devops"},
-	{"gitlab ci", "GitLab CI", "devops"},
-	{"travis", "Travis CI", "devops"},
-	{"helm", "Helm", "devops"},
-	{"prometheus", "Prometheus", "devops"},
-	{"grafana", "Grafana", "devops"},
-	{"datadog", "Datadog", "devops"},
-	{"new relic", "New Relic", "devops"},
-	{"nginx", "Nginx", "devops"},
-	{"apache", "Apache", "devops"},
-	{"istio", "Istio", "devops"},
-	{"envoy", "Envoy", "devops"},
-	{"consul", "Consul", "devops"},
-	{"vault", "Vault", "devops"},
+	// --- devops (25) ---
+	{Keyword: "docker", Skill: "Docker", Category: "devops"},
+	{Keyword: "kubernetes", Skill: "Kubernetes", Category: "devops"},
+	{Keyword: "k8s", Skill: "Kubernetes", Category: "devops"},
+	{Keyword: "terraform", Skill: "Terraform", Category: "devops"},
+	{Keyword: "ansible", Skill: "Ansible", Category: "devops"},
+	{Keyword: "puppet", Skill: "Puppet", Category: "devops"},
+	{Keyword: "chef", Skill: "Chef", Category: "devops"},
+	{Keyword: "jenkins", Skill: "Jenkins", Category: "devops"},
+	{Keyword: "github actions", Skill: "GitHub Actions", Category: "devops"},
+	{Keyword: "gitlab ci", Skill: "GitLab CI", Category: "devops"},
+	{Keyword: "circleci", Skill: "CircleCI", Category: "devops"},
+	{Keyword: "ci/cd", Skill: "CI/CD", Category: "devops"},
+	{Keyword: "nginx", Skill: "Nginx", Category: "devops"},
+	{Keyword: "apache", Skill: "Apache", Category: "devops"},
+	{Keyword: "vagrant", Skill: "Vagrant", Category: "devops"},
+	{Keyword: "deployment", Skill: "Deployment", Category: "devops"},
+	{Keyword: "infrastructure", Skill: "Infrastructure", Category: "devops"},
+	{Keyword: "server management", Skill: "Server Management", Category: "devops"},
+	{Keyword: "system administration", Skill: "System Administration", Category: "devops"},
+	{Keyword: "shell", Skill: "Shell Scripting", Category: "devops"},
+	{Keyword: "bash", Skill: "Bash", Category: "devops"},
+	{Keyword: "cron", Skill: "Cron", Category: "devops"},
+	{Keyword: "git flow", Skill: "Git Flow", Category: "devops"},
+	{Keyword: "git hooks", Skill: "Git Hooks", Category: "devops"},
+	{Keyword: "operations", Skill: "Operations", Category: "devops"},
+	{Keyword: "networking", Skill: "Networking", Category: "devops"},
+	{Keyword: "helm", Skill: "Helm", Category: "devops"},
+	{Keyword: "argocd", Skill: "ArgoCD", Category: "devops"},
+	{Keyword: "packer", Skill: "Packer", Category: "devops"},
+	{Keyword: "consul", Skill: "Consul", Category: "devops"},
+	{Keyword: "istio", Skill: "Istio", Category: "devops"},
+	{Keyword: "travis ci", Skill: "Travis CI", Category: "devops"},
+	{Keyword: "capistrano", Skill: "Capistrano", Category: "devops"},
 
-	// ========================================
-	// CLOUD PLATFORMS & SERVICES (23)
-	// ========================================
-	{"aws", "AWS", "cloud"},
-	{"amazon web services", "AWS", "cloud"},
-	{"ec2", "AWS EC2", "cloud"},
-	{"s3", "AWS S3", "cloud"},
-	{"lambda", "AWS Lambda", "cloud"},
-	{"rds", "AWS RDS", "cloud"},
-	{"ecs", "AWS ECS", "cloud"},
-	{"eks", "AWS EKS", "cloud"},
-	{"sqs", "AWS SQS", "cloud"},
-	{"sns", "AWS SNS", "cloud"},
-	{"cloudformation", "CloudFormation", "cloud"},
-	{"gcp", "Google Cloud", "cloud"},
-	{"google cloud", "Google Cloud", "cloud"},
-	{"bigquery", "BigQuery", "cloud"},
-	{"cloud run", "Cloud Run", "cloud"},
-	{"gke", "Google Kubernetes Engine", "cloud"},
-	{"azure", "Azure", "cloud"},
-	{"heroku", "Heroku", "cloud"},
-	{"vercel", "Vercel", "cloud"},
-	{"netlify", "Netlify", "cloud"},
-	{"cloudflare", "Cloudflare", "cloud"},
-	{"digitalocean", "DigitalOcean", "cloud"},
-	{"linode", "Linode", "cloud"},
+	// --- database (18) ---
+	{Keyword: "postgresql", Skill: "PostgreSQL", Category: "database"},
+	{Keyword: "postgres", Skill: "PostgreSQL", Category: "database"},
+	{Keyword: "mysql", Skill: "MySQL", Category: "database"},
+	{Keyword: "mongodb", Skill: "MongoDB", Category: "database"},
+	{Keyword: "redis", Skill: "Redis", Category: "database"},
+	{Keyword: "elasticsearch", Skill: "Elasticsearch", Category: "database"},
+	{Keyword: "sqlite", Skill: "SQLite", Category: "database"},
+	{Keyword: "sql", Skill: "SQL", Category: "database"},
+	{Keyword: "dynamodb", Skill: "DynamoDB", Category: "database"},
+	{Keyword: "cassandra", Skill: "Cassandra", Category: "database"},
+	{Keyword: "couchdb", Skill: "CouchDB", Category: "database"},
+	{Keyword: "oracle", Skill: "Oracle DB", Category: "database"},
+	{Keyword: "nosql", Skill: "NoSQL", Category: "database"},
+	{Keyword: "database migrations", Skill: "Database Migrations", Category: "database"},
+	{Keyword: "database optimization", Skill: "Database Optimization", Category: "database"},
+	{Keyword: "database performance", Skill: "Database Performance", Category: "database"},
+	{Keyword: "data modeling", Skill: "Data Modeling", Category: "database"},
+	{Keyword: "data integrity", Skill: "Data Integrity", Category: "database"},
+	{Keyword: "mariadb", Skill: "MariaDB", Category: "database"},
+	{Keyword: "neo4j", Skill: "Neo4j", Category: "database"},
+	{Keyword: "memcached", Skill: "Memcached", Category: "database"},
+	{Keyword: "influxdb", Skill: "InfluxDB", Category: "database"},
 
-	// ========================================
-	// MOBILE DEVELOPMENT (10)
-	// ========================================
-	{"ios", "iOS", "mobile"},
-	{"android", "Android", "mobile"},
-	{"swift", "Swift", "mobile"},
-	{"objective-c", "Objective-C", "mobile"},
-	{"objective c", "Objective-C", "mobile"},
-	{"kotlin", "Kotlin", "mobile"},
-	{"react native", "React Native", "mobile"},
-	{"flutter", "Flutter", "mobile"},
-	{"xamarin", "Xamarin", "mobile"},
-	{"ionic", "Ionic", "mobile"},
+	// --- cloud (8) ---
+	{Keyword: "aws", Skill: "AWS", Category: "cloud"},
+	{Keyword: "gcp", Skill: "GCP", Category: "cloud"},
+	{Keyword: "google cloud", Skill: "Google Cloud", Category: "cloud"},
+	{Keyword: "azure", Skill: "Azure", Category: "cloud"},
+	{Keyword: "heroku", Skill: "Heroku", Category: "cloud"},
+	{Keyword: "digitalocean", Skill: "DigitalOcean", Category: "cloud"},
+	{Keyword: "serverless", Skill: "Serverless", Category: "cloud"},
+	{Keyword: "cloudflare", Skill: "Cloudflare", Category: "cloud"},
 
-	// ========================================
-	// TOOLING & PROTOCOLS (19)
-	// ========================================
-	{"git", "Git", "tooling"},
-	{"github", "GitHub", "tooling"},
-	{"gitlab", "GitLab", "tooling"},
-	{"bitbucket", "Bitbucket", "tooling"},
-	{"jira", "Jira", "tooling"},
-	{"confluence", "Confluence", "tooling"},
-	{"slack", "Slack", "tooling"},
-	{"figma", "Figma", "tooling"},
-	{"sketch", "Sketch", "tooling"},
-	{"graphql", "GraphQL", "tooling"},
-	{"rest", "REST API", "tooling"},
-	{"rest api", "REST API", "tooling"},
-	{"grpc", "gRPC", "tooling"},
-	{"rabbitmq", "RabbitMQ", "tooling"},
-	{"kafka", "Kafka", "tooling"},
-	{"oauth", "OAuth", "tooling"},
-	{"jwt", "JWT", "tooling"},
-	{"websocket", "WebSocket", "tooling"},
-	{"protobuf", "Protocol Buffers", "tooling"},
+	// --- mobile (6) ---
+	{Keyword: "react native", Skill: "React Native", Category: "mobile"},
+	{Keyword: "flutter", Skill: "Flutter", Category: "mobile"},
+	{Keyword: "ios", Skill: "iOS", Category: "mobile"},
+	{Keyword: "android", Skill: "Android", Category: "mobile"},
+	{Keyword: "xamarin", Skill: "Xamarin", Category: "mobile"},
+	{Keyword: "ionic", Skill: "Ionic", Category: "mobile"},
 
-	// ========================================
-	// TESTING FRAMEWORKS (15)
-	// ========================================
-	{"jest", "Jest", "testing"},
-	{"mocha", "Mocha", "testing"},
-	{"chai", "Chai", "testing"},
-	{"jasmine", "Jasmine", "testing"},
-	{"pytest", "Pytest", "testing"},
-	{"junit", "JUnit", "testing"},
-	{"testng", "TestNG", "testing"},
-	{"rspec", "RSpec", "testing"},
-	{"cypress", "Cypress", "testing"},
-	{"selenium", "Selenium", "testing"},
-	{"playwright", "Playwright", "testing"},
-	{"webdriverio", "WebDriverIO", "testing"},
-	{"cucumber", "Cucumber", "testing"},
-	{"postman", "Postman", "testing"},
-	{"insomnia", "Insomnia", "testing"},
+	// --- tooling (32) ---
+	{Keyword: "git", Skill: "Git", Category: "tooling"},
+	{Keyword: "github", Skill: "GitHub", Category: "tooling"},
+	{Keyword: "gitlab", Skill: "GitLab", Category: "tooling"},
+	{Keyword: "bitbucket", Skill: "Bitbucket", Category: "tooling"},
+	{Keyword: "jira", Skill: "Jira", Category: "tooling"},
+	{Keyword: "confluence", Skill: "Confluence", Category: "tooling"},
+	{Keyword: "slack", Skill: "Slack", Category: "tooling"},
+	{Keyword: "vim", Skill: "Vim", Category: "tooling"},
+	{Keyword: "neovim", Skill: "Neovim", Category: "tooling"},
+	{Keyword: "vscode", Skill: "VS Code", Category: "tooling"},
+	{Keyword: "intellij", Skill: "IntelliJ", Category: "tooling"},
+	{Keyword: "postman", Skill: "Postman", Category: "tooling"},
+	{Keyword: "swagger", Skill: "Swagger", Category: "tooling"},
+	{Keyword: "make", Skill: "Make", Category: "tooling"},
+	{Keyword: "cmake", Skill: "CMake", Category: "tooling"},
+	{Keyword: "gradle", Skill: "Gradle", Category: "tooling"},
+	{Keyword: "maven", Skill: "Maven", Category: "tooling"},
+	{Keyword: "npm", Skill: "npm", Category: "tooling"},
+	{Keyword: "yarn", Skill: "Yarn", Category: "tooling"},
+	{Keyword: "pip", Skill: "pip", Category: "tooling"},
+	{Keyword: "homebrew", Skill: "Homebrew", Category: "tooling"},
+	{Keyword: "linux", Skill: "Linux", Category: "tooling"},
+	{Keyword: "macos", Skill: "macOS", Category: "tooling"},
+	{Keyword: "windows", Skill: "Windows", Category: "tooling"},
+	{Keyword: "documentation", Skill: "Documentation", Category: "tooling"},
+	{Keyword: "technical documentation", Skill: "Technical Documentation", Category: "tooling"},
+	{Keyword: "markdown", Skill: "Markdown", Category: "tooling"},
+	{Keyword: "xml", Skill: "XML", Category: "tooling"},
+	{Keyword: "json", Skill: "JSON", Category: "tooling"},
+	{Keyword: "csv", Skill: "CSV", Category: "tooling"},
+	{Keyword: "regex", Skill: "Regex", Category: "tooling"},
+	{Keyword: "figma", Skill: "Figma", Category: "tooling"},
+	{Keyword: "trello", Skill: "Trello", Category: "tooling"},
+	{Keyword: "notion", Skill: "Notion", Category: "tooling"},
+	{Keyword: "asana", Skill: "Asana", Category: "tooling"},
+	{Keyword: "docker compose", Skill: "Docker Compose", Category: "tooling"},
+	{Keyword: "openapi", Skill: "OpenAPI", Category: "tooling"},
+	{Keyword: "mermaid", Skill: "Mermaid", Category: "tooling"},
+	{Keyword: "graphviz", Skill: "Graphviz", Category: "tooling"},
+	{Keyword: "yaml", Skill: "YAML", Category: "tooling"},
+	{Keyword: "toml", Skill: "TOML", Category: "tooling"},
+	{Keyword: "protobuf", Skill: "Protocol Buffers", Category: "tooling"},
 
-	// ========================================
-	// BUILD TOOLS & PACKAGE MANAGERS (12)
-	// ========================================
-	{"maven", "Maven", "tooling"},
-	{"gradle", "Gradle", "tooling"},
-	{"make", "Make", "tooling"},
-	{"bazel", "Bazel", "tooling"},
-	{"npm", "npm", "tooling"},
-	{"yarn", "Yarn", "tooling"},
-	{"pnpm", "pnpm", "tooling"},
-	{"pip", "pip", "tooling"},
-	{"poetry", "Poetry", "tooling"},
-	{"bundler", "Bundler", "tooling"},
-	{"cargo", "Cargo", "tooling"},
-	{"cmake", "CMake", "tooling"},
+	// --- testing (18) ---
+	{Keyword: "testing", Skill: "Testing", Category: "testing"},
+	{Keyword: "unit testing", Skill: "Unit Testing", Category: "testing"},
+	{Keyword: "integration testing", Skill: "Integration Testing", Category: "testing"},
+	{Keyword: "e2e testing", Skill: "E2E Testing", Category: "testing"},
+	{Keyword: "automated testing", Skill: "Automated Testing", Category: "testing"},
+	{Keyword: "jest", Skill: "Jest", Category: "testing"},
+	{Keyword: "mocha", Skill: "Mocha", Category: "testing"},
+	{Keyword: "rspec", Skill: "RSpec", Category: "testing"},
+	{Keyword: "pytest", Skill: "pytest", Category: "testing"},
+	{Keyword: "cypress", Skill: "Cypress", Category: "testing"},
+	{Keyword: "selenium", Skill: "Selenium", Category: "testing"},
+	{Keyword: "ginkgo", Skill: "Ginkgo", Category: "testing"},
+	{Keyword: "gomega", Skill: "Gomega", Category: "testing"},
+	{Keyword: "code coverage", Skill: "Code Coverage", Category: "testing"},
+	{Keyword: "quality assurance", Skill: "Quality Assurance", Category: "testing"},
+	{Keyword: "load testing", Skill: "Load Testing", Category: "testing"},
+	{Keyword: "test automation", Skill: "Test Automation", Category: "testing"},
+	{Keyword: "cucumber", Skill: "Cucumber", Category: "testing"},
 
-	// ========================================
-	// MACHINE LEARNING & DATA SCIENCE (10)
-	// ========================================
-	{"tensorflow", "TensorFlow", "ml"},
-	{"pytorch", "PyTorch", "ml"},
-	{"scikit-learn", "scikit-learn", "ml"},
-	{"sklearn", "scikit-learn", "ml"},
-	{"pandas", "Pandas", "ml"},
-	{"numpy", "NumPy", "ml"},
-	{"keras", "Keras", "ml"},
-	{"jupyter", "Jupyter", "ml"},
-	{"openai", "OpenAI", "ml"},
-	{"langchain", "LangChain", "ml"},
+	// --- monitoring (14) ---
+	{Keyword: "prometheus", Skill: "Prometheus", Category: "monitoring"},
+	{Keyword: "grafana", Skill: "Grafana", Category: "monitoring"},
+	{Keyword: "datadog", Skill: "Datadog", Category: "monitoring"},
+	{Keyword: "new relic", Skill: "New Relic", Category: "monitoring"},
+	{Keyword: "sentry", Skill: "Sentry", Category: "monitoring"},
+	{Keyword: "elk", Skill: "ELK Stack", Category: "monitoring"},
+	{Keyword: "logging", Skill: "Logging", Category: "monitoring"},
+	{Keyword: "structured logging", Skill: "Structured Logging", Category: "monitoring"},
+	{Keyword: "alerting", Skill: "Alerting", Category: "monitoring"},
+	{Keyword: "metrics", Skill: "Metrics", Category: "monitoring"},
+	{Keyword: "observability", Skill: "Observability", Category: "monitoring"},
+	{Keyword: "monitoring", Skill: "Monitoring", Category: "monitoring"},
+	{Keyword: "splunk", Skill: "Splunk", Category: "monitoring"},
+	{Keyword: "pagerduty", Skill: "PagerDuty", Category: "monitoring"},
 
-	// ========================================
-	// DATA ENGINEERING (9)
-	// ========================================
-	{"apache spark", "Apache Spark", "data"},
-	{"spark", "Apache Spark", "data"},
-	{"airflow", "Apache Airflow", "data"},
-	{"databricks", "Databricks", "data"},
-	{"snowflake", "Snowflake", "data"},
-	{"dbt", "dbt", "data"},
-	{"hadoop", "Hadoop", "data"},
-	{"hive", "Hive", "data"},
-	{"presto", "Presto", "data"},
+	// --- data (10) ---
+	{Keyword: "etl", Skill: "ETL", Category: "data"},
+	{Keyword: "data processing", Skill: "Data Processing", Category: "data"},
+	{Keyword: "data export", Skill: "Data Export", Category: "data"},
+	{Keyword: "data platforms", Skill: "Data Platforms", Category: "data"},
+	{Keyword: "analytics", Skill: "Analytics", Category: "data"},
+	{Keyword: "business intelligence", Skill: "Business Intelligence", Category: "data"},
+	{Keyword: "reporting", Skill: "Reporting", Category: "data"},
+	{Keyword: "apache spark", Skill: "Apache Spark", Category: "data"},
+	{Keyword: "kafka", Skill: "Kafka", Category: "data"},
+	{Keyword: "rabbitmq", Skill: "RabbitMQ", Category: "data"},
 
-	// ========================================
-	// MONITORING & OBSERVABILITY (7)
-	// ========================================
-	{"splunk", "Splunk", "monitoring"},
-	{"elk stack", "ELK Stack", "monitoring"},
-	{"kibana", "Kibana", "monitoring"},
-	{"logstash", "Logstash", "monitoring"},
-	{"sentry", "Sentry", "monitoring"},
-	{"pagerduty", "PagerDuty", "monitoring"},
-	{"honeycomb", "Honeycomb", "monitoring"},
+	// --- ml (10) ---
+	{Keyword: "machine learning", Skill: "Machine Learning", Category: "ml"},
+	{Keyword: "deep learning", Skill: "Deep Learning", Category: "ml"},
+	{Keyword: "tensorflow", Skill: "TensorFlow", Category: "ml"},
+	{Keyword: "pytorch", Skill: "PyTorch", Category: "ml"},
+	{Keyword: "natural language processing", Skill: "NLP", Category: "ml"},
+	{Keyword: "nlp", Skill: "NLP", Category: "ml"},
+	{Keyword: "ai", Skill: "AI", Category: "ml"},
+	{Keyword: "generative ai", Skill: "Generative AI", Category: "ml"},
+	{Keyword: "llms", Skill: "LLMs", Category: "ml"},
+	{Keyword: "prompt engineering", Skill: "Prompt Engineering", Category: "ml"},
+	{Keyword: "computer vision", Skill: "Computer Vision", Category: "ml"},
+	{Keyword: "scikit-learn", Skill: "scikit-learn", Category: "ml"},
 
-	// ========================================
-	// DOCUMENTATION TOOLS (6)
-	// ========================================
-	{"swagger", "Swagger", "tooling"},
-	{"openapi", "OpenAPI", "tooling"},
-	{"redoc", "Redoc", "tooling"},
-	{"docusaurus", "Docusaurus", "tooling"},
-	{"mkdocs", "MkDocs", "tooling"},
-	{"sphinx", "Sphinx", "tooling"},
+	// --- architecture (30) ---
+	{Keyword: "microservices", Skill: "Microservices", Category: "architecture"},
+	{Keyword: "monolith", Skill: "Monolithic Architecture", Category: "architecture"},
+	{Keyword: "soa", Skill: "SOA", Category: "architecture"},
+	{Keyword: "service-oriented architecture", Skill: "SOA", Category: "architecture"},
+	{Keyword: "domain-driven design", Skill: "Domain-Driven Design", Category: "architecture"},
+	{Keyword: "ddd", Skill: "Domain-Driven Design", Category: "architecture"},
+	{Keyword: "event-driven", Skill: "Event-Driven Architecture", Category: "architecture"},
+	{Keyword: "event sourcing", Skill: "Event Sourcing", Category: "architecture"},
+	{Keyword: "cqrs", Skill: "CQRS", Category: "architecture"},
+	{Keyword: "distributed systems", Skill: "Distributed Systems", Category: "architecture"},
+	{Keyword: "system design", Skill: "System Design", Category: "architecture"},
+	{Keyword: "scalability", Skill: "Scalability", Category: "architecture"},
+	{Keyword: "high availability", Skill: "High Availability", Category: "architecture"},
+	{Keyword: "fault tolerance", Skill: "Fault Tolerance", Category: "architecture"},
+	{Keyword: "load balancing", Skill: "Load Balancing", Category: "architecture"},
+	{Keyword: "caching", Skill: "Caching", Category: "architecture"},
+	{Keyword: "message queues", Skill: "Message Queues", Category: "architecture"},
+	{Keyword: "pub/sub", Skill: "Pub/Sub", Category: "architecture"},
+	{Keyword: "dependency injection", Skill: "Dependency Injection", Category: "architecture"},
+	{Keyword: "design patterns", Skill: "Design Patterns", Category: "architecture"},
+	{Keyword: "solid", Skill: "SOLID Principles", Category: "architecture"},
+	{Keyword: "clean architecture", Skill: "Clean Architecture", Category: "architecture"},
+	{Keyword: "hexagonal architecture", Skill: "Hexagonal Architecture", Category: "architecture"},
+	{Keyword: "api gateway", Skill: "API Gateway", Category: "architecture"},
+	{Keyword: "state machine", Skill: "State Machine", Category: "architecture"},
+	{Keyword: "concurrency", Skill: "Concurrency", Category: "architecture"},
+	{Keyword: "multithreading", Skill: "Multithreading", Category: "architecture"},
+	{Keyword: "data structures", Skill: "Data Structures", Category: "architecture"},
+	{Keyword: "algorithms", Skill: "Algorithms", Category: "architecture"},
+	{Keyword: "software architecture", Skill: "Software Architecture", Category: "architecture"},
+	{Keyword: "twelve-factor", Skill: "Twelve-Factor App", Category: "architecture"},
+	{Keyword: "saga pattern", Skill: "Saga Pattern", Category: "architecture"},
+	{Keyword: "circuit breaker", Skill: "Circuit Breaker", Category: "architecture"},
+	{Keyword: "rate limiting", Skill: "Rate Limiting", Category: "architecture"},
+	{Keyword: "idempotency", Skill: "Idempotency", Category: "architecture"},
 
-	// ========================================
-	// OPERATING SYSTEMS (7)
-	// ========================================
-	{"linux", "Linux", "devops"},
-	{"unix", "Unix", "devops"},
-	{"ubuntu", "Ubuntu", "devops"},
-	{"debian", "Debian", "devops"},
-	{"centos", "CentOS", "devops"},
-	{"macos", "macOS", "devops"},
-	{"windows server", "Windows Server", "devops"},
+	// --- security (15) ---
+	{Keyword: "security", Skill: "Security", Category: "security"},
+	{Keyword: "authentication", Skill: "Authentication", Category: "security"},
+	{Keyword: "authorization", Skill: "Authorization", Category: "security"},
+	{Keyword: "oauth", Skill: "OAuth", Category: "security"},
+	{Keyword: "oauth2", Skill: "OAuth 2.0", Category: "security"},
+	{Keyword: "jwt", Skill: "JWT", Category: "security"},
+	{Keyword: "tls", Skill: "TLS", Category: "security"},
+	{Keyword: "ssl", Skill: "SSL", Category: "security"},
+	{Keyword: "pki", Skill: "PKI", Category: "security"},
+	{Keyword: "pci", Skill: "PCI Compliance", Category: "security"},
+	{Keyword: "saml", Skill: "SAML", Category: "security"},
+	{Keyword: "active directory", Skill: "Active Directory", Category: "security"},
+	{Keyword: "compliance", Skill: "Compliance", Category: "security"},
+	{Keyword: "encryption", Skill: "Encryption", Category: "security"},
+	{Keyword: "penetration testing", Skill: "Penetration Testing", Category: "security"},
+	{Keyword: "owasp", Skill: "OWASP", Category: "security"},
+	{Keyword: "sso", Skill: "Single Sign-On", Category: "security"},
+	{Keyword: "rbac", Skill: "RBAC", Category: "security"},
+	{Keyword: "gdpr", Skill: "GDPR", Category: "security"},
+	{Keyword: "soc2", Skill: "SOC 2", Category: "security"},
 
-	// ========================================
-	// MODERN RUNTIMES & FRAMEWORKS (8)
-	// ========================================
-	{"deno", "Deno", "backend"},
-	{"bun", "Bun", "backend"},
-	{"astro", "Astro", "frontend"},
-	{"remix", "Remix", "frontend"},
-	{"solidjs", "SolidJS", "frontend"},
-	{"qwik", "Qwik", "frontend"},
-	{"fresh", "Fresh", "frontend"},
-	{"hono", "Hono", "backend"},
+	// --- practices (30) ---
+	{Keyword: "agile", Skill: "Agile", Category: "practices"},
+	{Keyword: "scrum", Skill: "Scrum", Category: "practices"},
+	{Keyword: "kanban", Skill: "Kanban", Category: "practices"},
+	{Keyword: "tdd", Skill: "TDD", Category: "practices"},
+	{Keyword: "test-driven development", Skill: "TDD", Category: "practices"},
+	{Keyword: "bdd", Skill: "BDD", Category: "practices"},
+	{Keyword: "behavior-driven development", Skill: "BDD", Category: "practices"},
+	{Keyword: "code review", Skill: "Code Review", Category: "practices"},
+	{Keyword: "pair programming", Skill: "Pair Programming", Category: "practices"},
+	{Keyword: "mob programming", Skill: "Mob Programming", Category: "practices"},
+	{Keyword: "refactoring", Skill: "Refactoring", Category: "practices"},
+	{Keyword: "code quality", Skill: "Code Quality", Category: "practices"},
+	{Keyword: "debugging", Skill: "Debugging", Category: "practices"},
+	{Keyword: "performance optimization", Skill: "Performance Optimization", Category: "practices"},
+	{Keyword: "feature flags", Skill: "Feature Flags", Category: "practices"},
+	{Keyword: "trunk-based development", Skill: "Trunk-Based Development", Category: "practices"},
+	{Keyword: "continuous integration", Skill: "Continuous Integration", Category: "practices"},
+	{Keyword: "continuous delivery", Skill: "Continuous Delivery", Category: "practices"},
+	{Keyword: "devops practices", Skill: "DevOps Practices", Category: "practices"},
+	{Keyword: "incident management", Skill: "Incident Management", Category: "practices"},
+	{Keyword: "on-call", Skill: "On-Call", Category: "practices"},
+	{Keyword: "retrospectives", Skill: "Retrospectives", Category: "practices"},
+	{Keyword: "sprint planning", Skill: "Sprint Planning", Category: "practices"},
+	{Keyword: "estimation", Skill: "Estimation", Category: "practices"},
+	{Keyword: "technical debt", Skill: "Technical Debt Management", Category: "practices"},
+	{Keyword: "documentation practices", Skill: "Documentation Practices", Category: "practices"},
+	{Keyword: "release management", Skill: "Release Management", Category: "practices"},
+	{Keyword: "version control", Skill: "Version Control", Category: "practices"},
+	{Keyword: "lean", Skill: "Lean", Category: "practices"},
+	{Keyword: "extreme programming", Skill: "Extreme Programming", Category: "practices"},
+	{Keyword: "post-mortems", Skill: "Post-Mortems", Category: "practices"},
+	{Keyword: "capacity planning", Skill: "Capacity Planning", Category: "practices"},
+	{Keyword: "chaos engineering", Skill: "Chaos Engineering", Category: "practices"},
+	{Keyword: "site reliability", Skill: "Site Reliability Engineering", Category: "practices"},
+	{Keyword: "sre", Skill: "SRE", Category: "practices"},
+	{Keyword: "runbooks", Skill: "Runbooks", Category: "practices"},
+	{Keyword: "knowledge sharing", Skill: "Knowledge Sharing", Category: "practices"},
+	{Keyword: "mentoring", Skill: "Mentoring", Category: "practices"},
+	{Keyword: "stakeholder management", Skill: "Stakeholder Management", Category: "practices"},
 }
 
-// GetTechnologyKeywords returns the complete list of technology keywords.
-// This is the master dictionary used for skill inference.
-func GetTechnologyKeywords() []TechnologyKeyword {
-	return technologyKeywords
-}
+// keywordIndex is a pre-built map from lowercase keyword to category for
+// constant-time lookups. It is built once at package init.
+var keywordIndex map[string]string
 
-// GetKeywordMap returns a map for O(1) keyword lookup.
-// This is used by the inference service for fast detection.
-func GetKeywordMap() map[string]TechnologyKeyword {
-	keywordMap := make(map[string]TechnologyKeyword, len(technologyKeywords))
-	for _, kw := range technologyKeywords {
-		keywordMap[kw.Keyword] = kw
+func init() {
+	keywordIndex = make(map[string]string, len(TechnologyKeywords))
+	for _, kw := range TechnologyKeywords {
+		keywordIndex[kw.Keyword] = kw.Category
 	}
-	return keywordMap
 }
 
-// GetCategoryForSkillName returns the category for a skill name by matching
-// against both canonical skill names and keywords (case-insensitive).
-// Returns empty string if no match found.
+// GetCategoryForSkillName performs a case-insensitive lookup of the given
+// skill name against the keyword dictionary. It returns the matching
+// category string, or an empty string if no match is found.
 func GetCategoryForSkillName(name string) string {
-	if name == "" {
-		return ""
-	}
-
 	lower := strings.ToLower(name)
-
-	for _, kw := range technologyKeywords {
-		if strings.EqualFold(kw.Skill, lower) || kw.Keyword == lower {
-			return kw.Category
-		}
+	if cat, ok := keywordIndex[lower]; ok {
+		return cat
 	}
-
 	return ""
-}
-
-// GetAllSkillNames returns unique canonical skill names.
-// Useful for deduplication and reporting.
-func GetAllSkillNames() []string {
-	seen := make(map[string]bool)
-	names := []string{}
-
-	for _, kw := range technologyKeywords {
-		if !seen[kw.Skill] {
-			seen[kw.Skill] = true
-			names = append(names, kw.Skill)
-		}
-	}
-
-	return names
 }

--- a/internal/service/career/technology/keywords.go
+++ b/internal/service/career/technology/keywords.go
@@ -70,7 +70,6 @@ var Keywords = []Entry{
 	{Keyword: "fastapi", Skill: "FastAPI", Category: "backend"},
 	{Keyword: ".net", Skill: ".NET", Category: "backend"},
 	{Keyword: "dotnet", Skill: ".NET", Category: "backend"},
-	{Keyword: "swift", Skill: "Swift", Category: "backend"},
 	{Keyword: "objective-c", Skill: "Objective-C", Category: "backend"},
 	{Keyword: "groovy", Skill: "Groovy", Category: "backend"},
 	{Keyword: "lua", Skill: "Lua", Category: "backend"},
@@ -223,6 +222,7 @@ var Keywords = []Entry{
 	{Keyword: "couchdb", Skill: "CouchDB", Category: "database"},
 	{Keyword: "oracle", Skill: "Oracle DB", Category: "database"},
 	{Keyword: "nosql", Skill: "NoSQL", Category: "database"},
+	{Keyword: "database design", Skill: "Database Design", Category: "database"},
 	{Keyword: "database migrations", Skill: "Database Migrations", Category: "database"},
 	{Keyword: "database optimization", Skill: "Database Optimization", Category: "database"},
 	{Keyword: "database performance", Skill: "Database Performance", Category: "database"},
@@ -251,6 +251,7 @@ var Keywords = []Entry{
 	{Keyword: "android", Skill: "Android", Category: "mobile"},
 	{Keyword: "xamarin", Skill: "Xamarin", Category: "mobile"},
 	{Keyword: "ionic", Skill: "Ionic", Category: "mobile"},
+	{Keyword: "swift", Skill: "Swift", Category: "mobile"},
 
 	// --- tooling ---
 	{Keyword: "git", Skill: "Git", Category: "tooling"},
@@ -317,6 +318,7 @@ var Keywords = []Entry{
 	{Keyword: "code coverage", Skill: "Code Coverage", Category: "testing"},
 	{Keyword: "quality assurance", Skill: "Quality Assurance", Category: "testing"},
 	{Keyword: "load testing", Skill: "Load Testing", Category: "testing"},
+	{Keyword: "performance testing", Skill: "Performance Testing", Category: "testing"},
 	{Keyword: "test automation", Skill: "Test Automation", Category: "testing"},
 	{Keyword: "cucumber", Skill: "Cucumber", Category: "testing"},
 	{Keyword: "playwright", Skill: "Playwright", Category: "testing"},
@@ -493,7 +495,6 @@ var Keywords = []Entry{
 	{Keyword: "mentoring", Skill: "Mentoring", Category: "practices"},
 	{Keyword: "stakeholder management", Skill: "Stakeholder Management", Category: "practices"},
 	{Keyword: "agile delivery", Skill: "Agile Delivery", Category: "practices"},
-	{Keyword: "analysis", Skill: "Analysis", Category: "practices"},
 	{Keyword: "application maintenance", Skill: "Application Maintenance", Category: "practices"},
 	{Keyword: "client collaboration", Skill: "Client Collaboration", Category: "practices"},
 	{Keyword: "client work", Skill: "Client Work", Category: "practices"},
@@ -521,10 +522,8 @@ var Keywords = []Entry{
 	{Keyword: "onboarding", Skill: "Onboarding", Category: "practices"},
 	{Keyword: "operational alignment", Skill: "Operational Alignment", Category: "practices"},
 	{Keyword: "optimization", Skill: "Optimization", Category: "practices"},
-	{Keyword: "performance", Skill: "Performance", Category: "practices"},
 	{Keyword: "performance engineering", Skill: "Performance Engineering", Category: "practices"},
 	{Keyword: "presentation", Skill: "Presentation", Category: "practices"},
-	{Keyword: "process", Skill: "Process", Category: "practices"},
 	{Keyword: "product development", Skill: "Product Development", Category: "practices"},
 	{Keyword: "product engineering", Skill: "Product Engineering", Category: "practices"},
 	{Keyword: "product management", Skill: "Product Management", Category: "practices"},
@@ -532,9 +531,7 @@ var Keywords = []Entry{
 	{Keyword: "project delivery", Skill: "Project Delivery", Category: "practices"},
 	{Keyword: "project handover", Skill: "Project Handover", Category: "practices"},
 	{Keyword: "project management", Skill: "Project Management", Category: "practices"},
-	{Keyword: "quality", Skill: "Quality", Category: "practices"},
 	{Keyword: "remote collaboration", Skill: "Remote Collaboration", Category: "practices"},
-	{Keyword: "review", Skill: "Review", Category: "practices"},
 	{Keyword: "software craft", Skill: "Software Craft", Category: "practices"},
 	{Keyword: "software engineering", Skill: "Software Engineering", Category: "practices"},
 	{Keyword: "stakeholder collaboration", Skill: "Stakeholder Collaboration", Category: "practices"},
@@ -545,9 +542,6 @@ var Keywords = []Entry{
 	{Keyword: "time management", Skill: "Time Management", Category: "practices"},
 	{Keyword: "training", Skill: "Training", Category: "practices"},
 	{Keyword: "workflow design", Skill: "Workflow Design", Category: "practices"},
-	{Keyword: "design", Skill: "Design", Category: "practices"},
-	{Keyword: "product", Skill: "Product", Category: "practices"},
-	{Keyword: "foundation", Skill: "Foundation", Category: "practices"},
 }
 
 // keywordIndex is a pre-built map from lowercase keyword to category for
@@ -596,18 +590,25 @@ func GetCategoryForSkillName(name string) string {
 // word boundaries on both sides. A word boundary is the start/end of the
 // string, any non-alphanumeric character, or a trailing plural "s".
 func containsKeywordAtBoundary(text, keyword string) bool {
-	idx := strings.Index(text, keyword)
-	if idx < 0 {
-		return false
+	offset := 0
+	for {
+		idx := strings.Index(text[offset:], keyword)
+		if idx < 0 {
+			return false
+		}
+		idx += offset
+
+		leftOK := idx == 0 || !isAlphanumeric(rune(text[idx-1]))
+		endPos := idx + len(keyword)
+		rightOK := endPos == len(text) ||
+			!isAlphanumeric(rune(text[endPos])) ||
+			(text[endPos] == 's' && (endPos+1 == len(text) || !isAlphanumeric(rune(text[endPos+1]))))
+
+		if leftOK && rightOK {
+			return true
+		}
+		offset = idx + 1
 	}
-
-	leftOK := idx == 0 || !isAlphanumeric(rune(text[idx-1]))
-	endPos := idx + len(keyword)
-	rightOK := endPos == len(text) ||
-		!isAlphanumeric(rune(text[endPos])) ||
-		(text[endPos] == 's' && (endPos+1 == len(text) || !isAlphanumeric(rune(text[endPos+1]))))
-
-	return leftOK && rightOK
 }
 
 func isAlphanumeric(r rune) bool {

--- a/internal/service/career/technology/keywords.go
+++ b/internal/service/career/technology/keywords.go
@@ -2,22 +2,27 @@
 // keyword-based categorization for career technologies.
 package technology
 
-import "strings"
+import (
+	"context"
+	"strings"
 
-// TechnologyKeyword maps a lowercase search keyword to a display-friendly
-// skill name and its canonical category. The keyword is used for
-// case-insensitive matching against user-entered skill names.
-type TechnologyKeyword struct {
+	careerRepo "github.com/baphled/kariya/internal/repository/career"
+)
+
+// Entry maps a lowercase search keyword to a display-friendly skill name
+// and its canonical category. The keyword is used for case-insensitive
+// matching against user-entered skill names.
+type Entry struct {
 	Keyword  string
 	Skill    string
 	Category string
 }
 
-// TechnologyKeywords is the canonical keyword dictionary mapping technology
-// names to their skill categories. Each entry has a lowercase keyword for
-// matching, a display-friendly skill name, and a category from
+// Keywords is the canonical keyword dictionary mapping technology names to
+// their skill categories. Each entry has a lowercase keyword for matching,
+// a display-friendly skill name, and a category from
 // constants.AllSkillCategories().
-var TechnologyKeywords = []TechnologyKeyword{
+var Keywords = []Entry{
 
 	// --- backend (35) ---
 	{Keyword: "go", Skill: "Go", Category: "backend"},
@@ -403,8 +408,8 @@ var TechnologyKeywords = []TechnologyKeyword{
 var keywordIndex map[string]string
 
 func init() {
-	keywordIndex = make(map[string]string, len(TechnologyKeywords))
-	for _, kw := range TechnologyKeywords {
+	keywordIndex = make(map[string]string, len(Keywords))
+	for _, kw := range Keywords {
 		keywordIndex[kw.Keyword] = kw.Category
 	}
 }
@@ -418,4 +423,52 @@ func GetCategoryForSkillName(name string) string {
 		return cat
 	}
 	return ""
+}
+
+// RecategorizeResult summarises the outcome of a bulk skill recategorization.
+type RecategorizeResult struct {
+	Total      int
+	Updated    int
+	Skipped    int
+	NoMatch    int
+	ByCategory map[string]int
+}
+
+// RecategorizeSkills iterates over all skills in the repository and updates
+// their category when the keyword dictionary provides a better match than
+// the current value. Skills that already have the correct category or have
+// no keyword match are left unchanged.
+func RecategorizeSkills(ctx context.Context, repo careerRepo.SkillRepository) (*RecategorizeResult, error) {
+	skills, err := repo.List(ctx, &careerRepo.SkillListFilters{})
+	if err != nil {
+		return nil, err
+	}
+
+	result := &RecategorizeResult{
+		Total:      len(skills),
+		ByCategory: make(map[string]int),
+	}
+
+	for _, skill := range skills {
+		newCategory := GetCategoryForSkillName(skill.Name)
+		if newCategory == "" {
+			result.NoMatch++
+			continue
+		}
+
+		if skill.Category == newCategory {
+			result.Skipped++
+			continue
+		}
+
+		skill.Category = newCategory
+		if err := repo.Update(ctx, skill); err != nil {
+			return nil, err
+		}
+
+		result.Updated++
+		result.ByCategory[newCategory]++
+	}
+
+	return result, nil
 }

--- a/internal/service/career/technology/keywords.go
+++ b/internal/service/career/technology/keywords.go
@@ -20,6 +20,12 @@ type Entry struct {
 	Category string
 }
 
+// TechnologyKeyword is an alias for Entry for backward compatibility.
+// Deprecated: Use Entry instead.
+//
+//nolint:revive // Intentional naming for backward compatibility
+type TechnologyKeyword = Entry
+
 // Keywords is the canonical keyword dictionary mapping technology names to
 // their skill categories. Each entry has a lowercase keyword for matching,
 // a display-friendly skill name, and a category from
@@ -661,4 +667,14 @@ func RecategorizeSkills(ctx context.Context, repo careerRepo.SkillRepository) (*
 	}
 
 	return result, nil
+}
+
+// GetKeywordMap returns a map from keyword to TechnologyKeyword for backward compatibility.
+// Deprecated: Use the keywordIndex map or GetCategoryForSkillName instead.
+func GetKeywordMap() map[string]TechnologyKeyword {
+	result := make(map[string]TechnologyKeyword, len(Keywords))
+	for _, entry := range Keywords {
+		result[entry.Keyword] = entry
+	}
+	return result
 }

--- a/internal/service/career/technology/keywords.go
+++ b/internal/service/career/technology/keywords.go
@@ -26,7 +26,7 @@ type Entry struct {
 // constants.AllSkillCategories().
 var Keywords = []Entry{
 
-	// --- backend (35) ---
+	// --- backend ---
 	{Keyword: "go", Skill: "Go", Category: "backend"},
 	{Keyword: "golang", Skill: "Go", Category: "backend"},
 	{Keyword: "ruby", Skill: "Ruby", Category: "backend"},
@@ -82,8 +82,26 @@ var Keywords = []Entry{
 	{Keyword: "delphi", Skill: "Delphi", Category: "backend"},
 	{Keyword: "asp.net", Skill: "ASP.NET", Category: "backend"},
 	{Keyword: "nestjs", Skill: "NestJS", Category: "backend"},
+	{Keyword: "api development", Skill: "API Development", Category: "backend"},
+	{Keyword: "api versioning", Skill: "API Versioning", Category: "backend"},
+	{Keyword: "backend development", Skill: "Backend Development", Category: "backend"},
+	{Keyword: "backend engineering", Skill: "Backend Engineering", Category: "backend"},
+	{Keyword: "cms", Skill: "CMS", Category: "backend"},
+	{Keyword: "crud", Skill: "CRUD", Category: "backend"},
+	{Keyword: "error handling", Skill: "Error Handling", Category: "backend"},
+	{Keyword: "full-stack development", Skill: "Full-stack Development", Category: "backend"},
+	{Keyword: "full stack development", Skill: "Full-stack Development", Category: "backend"},
+	{Keyword: "integration", Skill: "Integration", Category: "backend"},
+	{Keyword: "pagination", Skill: "Pagination", Category: "backend"},
+	{Keyword: "serialization", Skill: "Serialization", Category: "backend"},
+	{Keyword: "validation", Skill: "Validation", Category: "backend"},
+	{Keyword: "web development", Skill: "Web Development", Category: "backend"},
+	{Keyword: "web", Skill: "Web", Category: "backend"},
+	{Keyword: "websocket", Skill: "WebSocket", Category: "backend"},
+	{Keyword: "generics", Skill: "Generics", Category: "backend"},
+	{Keyword: "go generics", Skill: "Go Generics", Category: "backend"},
 
-	// --- frontend (25) ---
+	// --- frontend ---
 	{Keyword: "javascript", Skill: "JavaScript", Category: "frontend"},
 	{Keyword: "typescript", Skill: "TypeScript", Category: "frontend"},
 	{Keyword: "react", Skill: "React", Category: "frontend"},
@@ -120,8 +138,29 @@ var Keywords = []Entry{
 	{Keyword: "nuxt.js", Skill: "Nuxt.js", Category: "frontend"},
 	{Keyword: "less", Skill: "Less", Category: "frontend"},
 	{Keyword: "styled-components", Skill: "Styled Components", Category: "frontend"},
+	{Keyword: "bubble tea", Skill: "Bubble Tea", Category: "frontend"},
+	{Keyword: "bubbletea", Skill: "Bubble Tea", Category: "frontend"},
+	{Keyword: "lipgloss", Skill: "Lipgloss", Category: "frontend"},
+	{Keyword: "vite", Skill: "Vite", Category: "frontend"},
+	{Keyword: "component library", Skill: "Component Library", Category: "frontend"},
+	{Keyword: "components", Skill: "Components", Category: "frontend"},
+	{Keyword: "form components", Skill: "Form Components", Category: "frontend"},
+	{Keyword: "filter design", Skill: "Filter Design", Category: "frontend"},
+	{Keyword: "frontend development", Skill: "Frontend Development", Category: "frontend"},
+	{Keyword: "frontend", Skill: "Frontend", Category: "frontend"},
+	{Keyword: "interface design", Skill: "Interface Design", Category: "frontend"},
+	{Keyword: "keyboard navigation", Skill: "Keyboard Navigation", Category: "frontend"},
+	{Keyword: "layout design", Skill: "Layout Design", Category: "frontend"},
+	{Keyword: "modal design", Skill: "Modal Design", Category: "frontend"},
+	{Keyword: "navigation", Skill: "Navigation", Category: "frontend"},
+	{Keyword: "theme system", Skill: "Theme System", Category: "frontend"},
+	{Keyword: "ux", Skill: "UX", Category: "frontend"},
+	{Keyword: "ux delivery", Skill: "UX Delivery", Category: "frontend"},
+	{Keyword: "user experience", Skill: "User Experience", Category: "frontend"},
+	{Keyword: "wizard design", Skill: "Wizard Design", Category: "frontend"},
+	{Keyword: "reusable components", Skill: "Reusable Components", Category: "frontend"},
 
-	// --- devops (25) ---
+	// --- devops ---
 	{Keyword: "docker", Skill: "Docker", Category: "devops"},
 	{Keyword: "kubernetes", Skill: "Kubernetes", Category: "devops"},
 	{Keyword: "k8s", Skill: "Kubernetes", Category: "devops"},
@@ -155,8 +194,22 @@ var Keywords = []Entry{
 	{Keyword: "istio", Skill: "Istio", Category: "devops"},
 	{Keyword: "travis ci", Skill: "Travis CI", Category: "devops"},
 	{Keyword: "capistrano", Skill: "Capistrano", Category: "devops"},
+	{Keyword: "devops", Skill: "DevOps", Category: "devops"},
+	{Keyword: "embedded systems", Skill: "Embedded Systems", Category: "devops"},
+	{Keyword: "firmware development", Skill: "Firmware Development", Category: "devops"},
+	{Keyword: "incident response", Skill: "Incident Response", Category: "devops"},
+	{Keyword: "iot", Skill: "IoT", Category: "devops"},
+	{Keyword: "migration", Skill: "Migration", Category: "devops"},
+	{Keyword: "migrations", Skill: "Migrations", Category: "devops"},
+	{Keyword: "operational support", Skill: "Operational Support", Category: "devops"},
+	{Keyword: "operational systems", Skill: "Operational Systems", Category: "devops"},
+	{Keyword: "production support", Skill: "Production Support", Category: "devops"},
+	{Keyword: "reliability engineering", Skill: "Reliability Engineering", Category: "devops"},
+	{Keyword: "reliability", Skill: "Reliability", Category: "devops"},
+	{Keyword: "system stability", Skill: "System Stability", Category: "devops"},
+	{Keyword: "system integration", Skill: "System Integration", Category: "devops"},
 
-	// --- database (18) ---
+	// --- database ---
 	{Keyword: "postgresql", Skill: "PostgreSQL", Category: "database"},
 	{Keyword: "postgres", Skill: "PostgreSQL", Category: "database"},
 	{Keyword: "mysql", Skill: "MySQL", Category: "database"},
@@ -179,8 +232,9 @@ var Keywords = []Entry{
 	{Keyword: "neo4j", Skill: "Neo4j", Category: "database"},
 	{Keyword: "memcached", Skill: "Memcached", Category: "database"},
 	{Keyword: "influxdb", Skill: "InfluxDB", Category: "database"},
+	{Keyword: "timescaledb", Skill: "TimescaleDB", Category: "database"},
 
-	// --- cloud (8) ---
+	// --- cloud ---
 	{Keyword: "aws", Skill: "AWS", Category: "cloud"},
 	{Keyword: "gcp", Skill: "GCP", Category: "cloud"},
 	{Keyword: "google cloud", Skill: "Google Cloud", Category: "cloud"},
@@ -190,7 +244,7 @@ var Keywords = []Entry{
 	{Keyword: "serverless", Skill: "Serverless", Category: "cloud"},
 	{Keyword: "cloudflare", Skill: "Cloudflare", Category: "cloud"},
 
-	// --- mobile (6) ---
+	// --- mobile ---
 	{Keyword: "react native", Skill: "React Native", Category: "mobile"},
 	{Keyword: "flutter", Skill: "Flutter", Category: "mobile"},
 	{Keyword: "ios", Skill: "iOS", Category: "mobile"},
@@ -198,7 +252,7 @@ var Keywords = []Entry{
 	{Keyword: "xamarin", Skill: "Xamarin", Category: "mobile"},
 	{Keyword: "ionic", Skill: "Ionic", Category: "mobile"},
 
-	// --- tooling (32) ---
+	// --- tooling ---
 	{Keyword: "git", Skill: "Git", Category: "tooling"},
 	{Keyword: "github", Skill: "GitHub", Category: "tooling"},
 	{Keyword: "gitlab", Skill: "GitLab", Category: "tooling"},
@@ -241,8 +295,12 @@ var Keywords = []Entry{
 	{Keyword: "yaml", Skill: "YAML", Category: "tooling"},
 	{Keyword: "toml", Skill: "TOML", Category: "tooling"},
 	{Keyword: "protobuf", Skill: "Protocol Buffers", Category: "tooling"},
+	{Keyword: "diagramming", Skill: "Diagramming", Category: "tooling"},
+	{Keyword: "technical writing", Skill: "Technical Writing", Category: "tooling"},
+	{Keyword: "automation", Skill: "Automation", Category: "tooling"},
+	{Keyword: "code generation", Skill: "Code Generation", Category: "tooling"},
 
-	// --- testing (18) ---
+	// --- testing ---
 	{Keyword: "testing", Skill: "Testing", Category: "testing"},
 	{Keyword: "unit testing", Skill: "Unit Testing", Category: "testing"},
 	{Keyword: "integration testing", Skill: "Integration Testing", Category: "testing"},
@@ -261,8 +319,10 @@ var Keywords = []Entry{
 	{Keyword: "load testing", Skill: "Load Testing", Category: "testing"},
 	{Keyword: "test automation", Skill: "Test Automation", Category: "testing"},
 	{Keyword: "cucumber", Skill: "Cucumber", Category: "testing"},
+	{Keyword: "playwright", Skill: "Playwright", Category: "testing"},
+	{Keyword: "benchmarking", Skill: "Benchmarking", Category: "testing"},
 
-	// --- monitoring (14) ---
+	// --- monitoring ---
 	{Keyword: "prometheus", Skill: "Prometheus", Category: "monitoring"},
 	{Keyword: "grafana", Skill: "Grafana", Category: "monitoring"},
 	{Keyword: "datadog", Skill: "Datadog", Category: "monitoring"},
@@ -277,8 +337,10 @@ var Keywords = []Entry{
 	{Keyword: "monitoring", Skill: "Monitoring", Category: "monitoring"},
 	{Keyword: "splunk", Skill: "Splunk", Category: "monitoring"},
 	{Keyword: "pagerduty", Skill: "PagerDuty", Category: "monitoring"},
+	{Keyword: "kibana", Skill: "Kibana", Category: "monitoring"},
+	{Keyword: "logstash", Skill: "Logstash", Category: "monitoring"},
 
-	// --- data (10) ---
+	// --- data ---
 	{Keyword: "etl", Skill: "ETL", Category: "data"},
 	{Keyword: "data processing", Skill: "Data Processing", Category: "data"},
 	{Keyword: "data export", Skill: "Data Export", Category: "data"},
@@ -289,8 +351,10 @@ var Keywords = []Entry{
 	{Keyword: "apache spark", Skill: "Apache Spark", Category: "data"},
 	{Keyword: "kafka", Skill: "Kafka", Category: "data"},
 	{Keyword: "rabbitmq", Skill: "RabbitMQ", Category: "data"},
+	{Keyword: "streaming", Skill: "Streaming", Category: "data"},
+	{Keyword: "rss", Skill: "RSS", Category: "data"},
 
-	// --- ml (10) ---
+	// --- ml ---
 	{Keyword: "machine learning", Skill: "Machine Learning", Category: "ml"},
 	{Keyword: "deep learning", Skill: "Deep Learning", Category: "ml"},
 	{Keyword: "tensorflow", Skill: "TensorFlow", Category: "ml"},
@@ -304,7 +368,7 @@ var Keywords = []Entry{
 	{Keyword: "computer vision", Skill: "Computer Vision", Category: "ml"},
 	{Keyword: "scikit-learn", Skill: "scikit-learn", Category: "ml"},
 
-	// --- architecture (30) ---
+	// --- architecture ---
 	{Keyword: "microservices", Skill: "Microservices", Category: "architecture"},
 	{Keyword: "monolith", Skill: "Monolithic Architecture", Category: "architecture"},
 	{Keyword: "soa", Skill: "SOA", Category: "architecture"},
@@ -340,6 +404,31 @@ var Keywords = []Entry{
 	{Keyword: "circuit breaker", Skill: "Circuit Breaker", Category: "architecture"},
 	{Keyword: "rate limiting", Skill: "Rate Limiting", Category: "architecture"},
 	{Keyword: "idempotency", Skill: "Idempotency", Category: "architecture"},
+	{Keyword: "adr", Skill: "ADR", Category: "architecture"},
+	{Keyword: "architecture", Skill: "Architecture", Category: "architecture"},
+	{Keyword: "asynchronous processing", Skill: "Asynchronous Processing", Category: "architecture"},
+	{Keyword: "backend architecture", Skill: "Backend Architecture", Category: "architecture"},
+	{Keyword: "backend systems", Skill: "Backend Systems", Category: "architecture"},
+	{Keyword: "background processing", Skill: "Background Processing", Category: "architecture"},
+	{Keyword: "builder pattern", Skill: "Builder Pattern", Category: "architecture"},
+	{Keyword: "component architecture", Skill: "Component Architecture", Category: "architecture"},
+	{Keyword: "high-throughput systems", Skill: "High-throughput Systems", Category: "architecture"},
+	{Keyword: "legacy modernization", Skill: "Legacy Modernization", Category: "architecture"},
+	{Keyword: "multi-language systems", Skill: "Multi-language Systems", Category: "architecture"},
+	{Keyword: "payment systems", Skill: "Payment Systems", Category: "architecture"},
+	{Keyword: "payments", Skill: "Payments", Category: "architecture"},
+	{Keyword: "order systems", Skill: "Order Systems", Category: "architecture"},
+	{Keyword: "real-time systems", Skill: "Real-time Systems", Category: "architecture"},
+	{Keyword: "repository pattern", Skill: "Repository Pattern", Category: "architecture"},
+	{Keyword: "resilience", Skill: "Resilience", Category: "architecture"},
+	{Keyword: "resilient systems", Skill: "Resilient Systems", Category: "architecture"},
+	{Keyword: "scalable systems", Skill: "Scalable Systems", Category: "architecture"},
+	{Keyword: "scaling systems", Skill: "Scaling Systems", Category: "architecture"},
+	{Keyword: "service architecture", Skill: "Service Architecture", Category: "architecture"},
+	{Keyword: "service integration", Skill: "Service Integration", Category: "architecture"},
+	{Keyword: "service layer", Skill: "Service Layer", Category: "architecture"},
+	{Keyword: "type safety", Skill: "Type Safety", Category: "architecture"},
+	{Keyword: "domain", Skill: "Domain", Category: "architecture"},
 
 	// --- security (15) ---
 	{Keyword: "security", Skill: "Security", Category: "security"},
@@ -363,7 +452,7 @@ var Keywords = []Entry{
 	{Keyword: "gdpr", Skill: "GDPR", Category: "security"},
 	{Keyword: "soc2", Skill: "SOC 2", Category: "security"},
 
-	// --- practices (30) ---
+	// --- practices ---
 	{Keyword: "agile", Skill: "Agile", Category: "practices"},
 	{Keyword: "scrum", Skill: "Scrum", Category: "practices"},
 	{Keyword: "kanban", Skill: "Kanban", Category: "practices"},
@@ -403,6 +492,62 @@ var Keywords = []Entry{
 	{Keyword: "knowledge sharing", Skill: "Knowledge Sharing", Category: "practices"},
 	{Keyword: "mentoring", Skill: "Mentoring", Category: "practices"},
 	{Keyword: "stakeholder management", Skill: "Stakeholder Management", Category: "practices"},
+	{Keyword: "agile delivery", Skill: "Agile Delivery", Category: "practices"},
+	{Keyword: "analysis", Skill: "Analysis", Category: "practices"},
+	{Keyword: "application maintenance", Skill: "Application Maintenance", Category: "practices"},
+	{Keyword: "client collaboration", Skill: "Client Collaboration", Category: "practices"},
+	{Keyword: "client work", Skill: "Client Work", Category: "practices"},
+	{Keyword: "code standards", Skill: "Code Standards", Category: "practices"},
+	{Keyword: "collaboration", Skill: "Collaboration", Category: "practices"},
+	{Keyword: "consulting", Skill: "Consulting", Category: "practices"},
+	{Keyword: "consulting delivery", Skill: "Consulting Delivery", Category: "practices"},
+	{Keyword: "cost optimization", Skill: "Cost Optimization", Category: "practices"},
+	{Keyword: "cross-functional collaboration", Skill: "Cross-functional Collaboration", Category: "practices"},
+	{Keyword: "cross-team collaboration", Skill: "Cross-team Collaboration", Category: "practices"},
+	{Keyword: "delivery", Skill: "Delivery", Category: "practices"},
+	{Keyword: "delivery management", Skill: "Delivery Management", Category: "practices"},
+	{Keyword: "developer experience", Skill: "Developer Experience", Category: "practices"},
+	{Keyword: "end-to-end delivery", Skill: "End-to-End Delivery", Category: "practices"},
+	{Keyword: "engineering judgment", Skill: "Engineering Judgment", Category: "practices"},
+	{Keyword: "engineering practices", Skill: "Engineering Practices", Category: "practices"},
+	{Keyword: "feature delivery", Skill: "Feature Delivery", Category: "practices"},
+	{Keyword: "full lifecycle delivery", Skill: "Full Lifecycle Delivery", Category: "practices"},
+	{Keyword: "incremental delivery", Skill: "Incremental Delivery", Category: "practices"},
+	{Keyword: "innovation", Skill: "Innovation", Category: "practices"},
+	{Keyword: "knowledge transfer", Skill: "Knowledge Transfer", Category: "practices"},
+	{Keyword: "leadership", Skill: "Leadership", Category: "practices"},
+	{Keyword: "learning", Skill: "Learning", Category: "practices"},
+	{Keyword: "maintenance", Skill: "Maintenance", Category: "practices"},
+	{Keyword: "onboarding", Skill: "Onboarding", Category: "practices"},
+	{Keyword: "operational alignment", Skill: "Operational Alignment", Category: "practices"},
+	{Keyword: "optimization", Skill: "Optimization", Category: "practices"},
+	{Keyword: "performance", Skill: "Performance", Category: "practices"},
+	{Keyword: "performance engineering", Skill: "Performance Engineering", Category: "practices"},
+	{Keyword: "presentation", Skill: "Presentation", Category: "practices"},
+	{Keyword: "process", Skill: "Process", Category: "practices"},
+	{Keyword: "product development", Skill: "Product Development", Category: "practices"},
+	{Keyword: "product engineering", Skill: "Product Engineering", Category: "practices"},
+	{Keyword: "product management", Skill: "Product Management", Category: "practices"},
+	{Keyword: "product support", Skill: "Product Support", Category: "practices"},
+	{Keyword: "project delivery", Skill: "Project Delivery", Category: "practices"},
+	{Keyword: "project handover", Skill: "Project Handover", Category: "practices"},
+	{Keyword: "project management", Skill: "Project Management", Category: "practices"},
+	{Keyword: "quality", Skill: "Quality", Category: "practices"},
+	{Keyword: "remote collaboration", Skill: "Remote Collaboration", Category: "practices"},
+	{Keyword: "review", Skill: "Review", Category: "practices"},
+	{Keyword: "software craft", Skill: "Software Craft", Category: "practices"},
+	{Keyword: "software engineering", Skill: "Software Engineering", Category: "practices"},
+	{Keyword: "stakeholder collaboration", Skill: "Stakeholder Collaboration", Category: "practices"},
+	{Keyword: "strategy", Skill: "Strategy", Category: "practices"},
+	{Keyword: "technical advisory", Skill: "Technical Advisory", Category: "practices"},
+	{Keyword: "technical debt management", Skill: "Technical Debt Management", Category: "practices"},
+	{Keyword: "technical leadership", Skill: "Technical Leadership", Category: "practices"},
+	{Keyword: "time management", Skill: "Time Management", Category: "practices"},
+	{Keyword: "training", Skill: "Training", Category: "practices"},
+	{Keyword: "workflow design", Skill: "Workflow Design", Category: "practices"},
+	{Keyword: "design", Skill: "Design", Category: "practices"},
+	{Keyword: "product", Skill: "Product", Category: "practices"},
+	{Keyword: "foundation", Skill: "Foundation", Category: "practices"},
 }
 
 // keywordIndex is a pre-built map from lowercase keyword to category for

--- a/internal/service/career/technology/keywords.go
+++ b/internal/service/career/technology/keywords.go
@@ -4,7 +4,9 @@ package technology
 
 import (
 	"context"
+	"sort"
 	"strings"
+	"unicode"
 
 	careerRepo "github.com/baphled/kariya/internal/repository/career"
 )
@@ -407,22 +409,64 @@ var Keywords = []Entry{
 // constant-time lookups. It is built once at package init.
 var keywordIndex map[string]string
 
+// substringKeywords holds keywords sorted by length descending for substring
+// matching. Longer keywords are checked first so that more specific matches
+// take priority (e.g. "event-driven" before "event").
+var substringKeywords []string
+
 func init() {
 	keywordIndex = make(map[string]string, len(Keywords))
 	for _, kw := range Keywords {
 		keywordIndex[kw.Keyword] = kw.Category
 	}
+
+	substringKeywords = make([]string, 0, len(keywordIndex))
+	for kw := range keywordIndex {
+		substringKeywords = append(substringKeywords, kw)
+	}
+	sort.Slice(substringKeywords, func(i, j int) bool {
+		return len(substringKeywords[i]) > len(substringKeywords[j])
+	})
 }
 
 // GetCategoryForSkillName performs a case-insensitive lookup of the given
-// skill name against the keyword dictionary. It returns the matching
-// category string, or an empty string if no match is found.
+// skill name against the keyword dictionary. It first tries an exact match,
+// then falls back to substring matching with word-boundary checks.
 func GetCategoryForSkillName(name string) string {
 	lower := strings.ToLower(name)
 	if cat, ok := keywordIndex[lower]; ok {
 		return cat
 	}
+
+	for _, kw := range substringKeywords {
+		if containsKeywordAtBoundary(lower, kw) {
+			return keywordIndex[kw]
+		}
+	}
+
 	return ""
+}
+
+// containsKeywordAtBoundary checks whether keyword appears in text with
+// word boundaries on both sides. A word boundary is the start/end of the
+// string, any non-alphanumeric character, or a trailing plural "s".
+func containsKeywordAtBoundary(text, keyword string) bool {
+	idx := strings.Index(text, keyword)
+	if idx < 0 {
+		return false
+	}
+
+	leftOK := idx == 0 || !isAlphanumeric(rune(text[idx-1]))
+	endPos := idx + len(keyword)
+	rightOK := endPos == len(text) ||
+		!isAlphanumeric(rune(text[endPos])) ||
+		(text[endPos] == 's' && (endPos+1 == len(text) || !isAlphanumeric(rune(text[endPos+1]))))
+
+	return leftOK && rightOK
+}
+
+func isAlphanumeric(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r)
 }
 
 // RecategorizeResult summarises the outcome of a bulk skill recategorization.

--- a/internal/service/career/technology/keywords_test.go
+++ b/internal/service/career/technology/keywords_test.go
@@ -1,297 +1,160 @@
 package technology_test
 
 import (
+	"strings"
+
+	"github.com/baphled/kariya/internal/constants"
 	"github.com/baphled/kariya/internal/service/career/technology"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("TechnologyKeywords", func() {
+var _ = Describe("Keywords", func() {
 	Describe("Dictionary Structure", func() {
-		It("should have at least 200 keyword entries", func() {
-			keywords := technology.GetTechnologyKeywords()
-			Expect(len(keywords)).To(BeNumerically(">=", 200),
-				"Expected at least 200 comprehensive keywords")
+		It("should have at least 350 keyword entries", func() {
+			Expect(len(technology.TechnologyKeywords)).To(BeNumerically(">=", 350))
 		})
 
-		It("should have all keywords in lowercase", func() {
-			keywords := technology.GetTechnologyKeywords()
-			for _, kw := range keywords {
-				// Check each character for uppercase
-				for _, ch := range kw.Keyword {
-					if ch >= 'A' && ch <= 'Z' {
-						Fail("Keyword \"" + kw.Keyword + "\" contains uppercase character")
-					}
-				}
+		It("should only use canonical categories from constants.AllSkillCategories", func() {
+			allCategories := constants.AllSkillCategories()
+			validCategories := make(map[string]bool, len(allCategories))
+			for _, cat := range allCategories {
+				validCategories[string(cat)] = true
+			}
+
+			for _, kw := range technology.TechnologyKeywords {
+				Expect(validCategories).To(HaveKey(kw.Category),
+					"keyword %q uses invalid category %q", kw.Keyword, kw.Category)
 			}
 		})
 
 		It("should have no duplicate keywords", func() {
-			keywords := technology.GetTechnologyKeywords()
 			seen := make(map[string]bool)
-
-			for _, kw := range keywords {
-				if seen[kw.Keyword] {
-					Fail("Duplicate keyword found: " + kw.Keyword)
-				}
+			for _, kw := range technology.TechnologyKeywords {
+				Expect(seen).NotTo(HaveKey(kw.Keyword),
+					"duplicate keyword: %q", kw.Keyword)
 				seen[kw.Keyword] = true
 			}
 		})
 
-		It("should only use canonical categories from constants.AllSkillCategories", func() {
-			keywords := technology.GetTechnologyKeywords()
-			validCategories := map[string]bool{
-				"backend":    true,
-				"frontend":   true,
-				"database":   true,
-				"devops":     true,
-				"cloud":      true,
-				"mobile":     true,
-				"tooling":    true,
-				"testing":    true,
-				"ml":         true,
-				"data":       true,
-				"monitoring": true,
-				"other":      true,
-			}
-
-			for _, kw := range keywords {
-				if !validCategories[kw.Category] {
-					Fail("Invalid category \"" + kw.Category + "\" for keyword \"" + kw.Keyword + "\". Must use canonical categories.")
-				}
+		It("should have all keywords in lowercase", func() {
+			for _, kw := range technology.TechnologyKeywords {
+				Expect(kw.Keyword).To(Equal(strings.ToLower(kw.Keyword)),
+					"keyword %q should be lowercase", kw.Keyword)
 			}
 		})
 
 		It("should have non-empty skill names", func() {
-			keywords := technology.GetTechnologyKeywords()
-			for _, kw := range keywords {
+			for _, kw := range technology.TechnologyKeywords {
 				Expect(kw.Skill).NotTo(BeEmpty(),
-					"Keyword %q has empty Skill field", kw.Keyword)
+					"keyword %q has empty skill name", kw.Keyword)
 			}
-		})
-
-		It("should have non-empty keywords", func() {
-			keywords := technology.GetTechnologyKeywords()
-			for _, kw := range keywords {
-				Expect(kw.Keyword).NotTo(BeEmpty(),
-					"Found keyword with empty Keyword field")
-			}
-		})
-	})
-
-	Describe("GetKeywordMap", func() {
-		It("should return a map with correct count", func() {
-			keywords := technology.GetTechnologyKeywords()
-			keywordMap := technology.GetKeywordMap()
-
-			Expect(keywordMap).To(HaveLen(len(keywords)),
-				"Map should have same count as slice")
-		})
-
-		It("should allow O(1) keyword lookup", func() {
-			keywordMap := technology.GetKeywordMap()
-
-			// Test a few expected keywords
-			expectedKeywords := []string{"go", "golang", "python", "react", "docker"}
-
-			for _, keyword := range expectedKeywords {
-				_, exists := keywordMap[keyword]
-				Expect(exists).To(BeTrue(),
-					"Expected keyword %q to exist in map", keyword)
-			}
-		})
-
-		It("should map keyword to correct TechnologyKeyword struct", func() {
-			keywordMap := technology.GetKeywordMap()
-
-			// Test specific mapping
-			goLang := keywordMap["go"]
-			Expect(goLang.Skill).To(Equal("Go"))
-			Expect(goLang.Category).To(Equal("backend"))
-
-			golangAlias := keywordMap["golang"]
-			Expect(golangAlias.Skill).To(Equal("Go"))
-			Expect(golangAlias.Category).To(Equal("backend"))
 		})
 	})
 
 	Describe("Keyword Coverage", func() {
-		It("should have backend keywords", func() {
-			keywords := technology.GetTechnologyKeywords()
-			backendCount := 0
-			for _, kw := range keywords {
-				if kw.Category == "backend" {
-					backendCount++
-				}
+		var categoryCounts map[string]int
+
+		BeforeEach(func() {
+			categoryCounts = make(map[string]int)
+			for _, kw := range technology.TechnologyKeywords {
+				categoryCounts[kw.Category]++
 			}
-			Expect(backendCount).To(BeNumerically(">=", 20),
-				"Expected at least 20 backend keywords, got %d", backendCount)
+		})
+
+		It("should have architecture keywords", func() {
+			Expect(categoryCounts["architecture"]).To(BeNumerically(">=", 25))
+		})
+
+		It("should have security keywords", func() {
+			Expect(categoryCounts["security"]).To(BeNumerically(">=", 12))
+		})
+
+		It("should have practices keywords", func() {
+			Expect(categoryCounts["practices"]).To(BeNumerically(">=", 25))
+		})
+
+		It("should have backend keywords", func() {
+			Expect(categoryCounts["backend"]).To(BeNumerically(">=", 30))
 		})
 
 		It("should have frontend keywords", func() {
-			keywords := technology.GetTechnologyKeywords()
-			frontendCount := 0
-			for _, kw := range keywords {
-				if kw.Category == "frontend" {
-					frontendCount++
-				}
-			}
-			Expect(frontendCount).To(BeNumerically(">=", 15),
-				"Expected at least 15 frontend keywords, got %d", frontendCount)
-		})
-
-		It("should have database keywords", func() {
-			keywords := technology.GetTechnologyKeywords()
-			databaseCount := 0
-			for _, kw := range keywords {
-				if kw.Category == "database" {
-					databaseCount++
-				}
-			}
-			Expect(databaseCount).To(BeNumerically(">=", 10),
-				"Expected at least 10 database keywords, got %d", databaseCount)
+			Expect(categoryCounts["frontend"]).To(BeNumerically(">=", 20))
 		})
 
 		It("should have devops keywords", func() {
-			keywords := technology.GetTechnologyKeywords()
-			devopsCount := 0
-			for _, kw := range keywords {
-				if kw.Category == "devops" {
-					devopsCount++
-				}
-			}
-			Expect(devopsCount).To(BeNumerically(">=", 10),
-				"Expected at least 10 devops keywords, got %d", devopsCount)
+			Expect(categoryCounts["devops"]).To(BeNumerically(">=", 20))
 		})
 
-		It("should have cloud keywords", func() {
-			keywords := technology.GetTechnologyKeywords()
-			cloudCount := 0
-			for _, kw := range keywords {
-				if kw.Category == "cloud" {
-					cloudCount++
-				}
-			}
-			Expect(cloudCount).To(BeNumerically(">=", 10),
-				"Expected at least 10 cloud keywords, got %d", cloudCount)
+		It("should have database keywords", func() {
+			Expect(categoryCounts["database"]).To(BeNumerically(">=", 14))
 		})
 
 		It("should have testing keywords", func() {
-			keywords := technology.GetTechnologyKeywords()
-			count := 0
-			for _, kw := range keywords {
-				if kw.Category == "testing" {
-					count++
-				}
-			}
-			Expect(count).To(BeNumerically(">=", 10),
-				"Expected at least 10 testing keywords, got %d", count)
-		})
-
-		It("should have tooling keywords including build tools and documentation", func() {
-			keywords := technology.GetTechnologyKeywords()
-			count := 0
-			for _, kw := range keywords {
-				if kw.Category == "tooling" {
-					count++
-				}
-			}
-			Expect(count).To(BeNumerically(">=", 30),
-				"Expected at least 30 tooling keywords (includes build tools and docs), got %d", count)
-		})
-
-		It("should have ML/data keywords", func() {
-			keywords := technology.GetTechnologyKeywords()
-			count := 0
-			for _, kw := range keywords {
-				if kw.Category == "ml" || kw.Category == "data" {
-					count++
-				}
-			}
-			Expect(count).To(BeNumerically(">=", 15),
-				"Expected at least 15 ML/data keywords, got %d", count)
+			Expect(categoryCounts["testing"]).To(BeNumerically(">=", 15))
 		})
 
 		It("should have monitoring keywords", func() {
-			keywords := technology.GetTechnologyKeywords()
-			count := 0
-			for _, kw := range keywords {
-				if kw.Category == "monitoring" {
-					count++
-				}
-			}
-			Expect(count).To(BeNumerically(">=", 5),
-				"Expected at least 5 monitoring keywords, got %d", count)
+			Expect(categoryCounts["monitoring"]).To(BeNumerically(">=", 10))
+		})
+
+		It("should have data keywords", func() {
+			Expect(categoryCounts["data"]).To(BeNumerically(">=", 7))
+		})
+
+		It("should have ml keywords", func() {
+			Expect(categoryCounts["ml"]).To(BeNumerically(">=", 8))
+		})
+
+		It("should have tooling keywords", func() {
+			Expect(categoryCounts["tooling"]).To(BeNumerically(">=", 30))
 		})
 	})
 
 	Describe("GetCategoryForSkillName", func() {
-		It("should return correct category for known canonical skill names", func() {
-			Expect(technology.GetCategoryForSkillName("Go")).To(Equal("backend"))
-			Expect(technology.GetCategoryForSkillName("PostgreSQL")).To(Equal("database"))
-			Expect(technology.GetCategoryForSkillName("Docker")).To(Equal("devops"))
-			Expect(technology.GetCategoryForSkillName("React")).To(Equal("frontend"))
-			Expect(technology.GetCategoryForSkillName("AWS")).To(Equal("cloud"))
-			Expect(technology.GetCategoryForSkillName("Jest")).To(Equal("testing"))
-			Expect(technology.GetCategoryForSkillName("Git")).To(Equal("tooling"))
-			Expect(technology.GetCategoryForSkillName("TensorFlow")).To(Equal("ml"))
-			Expect(technology.GetCategoryForSkillName("Apache Spark")).To(Equal("data"))
-			Expect(technology.GetCategoryForSkillName("Splunk")).To(Equal("monitoring"))
-			Expect(technology.GetCategoryForSkillName("iOS")).To(Equal("mobile"))
+		It("should return architecture for architectural concepts", func() {
+			Expect(technology.GetCategoryForSkillName("Microservices")).To(Equal("architecture"))
 		})
 
-		It("should match case-insensitively", func() {
-			Expect(technology.GetCategoryForSkillName("go")).To(Equal("backend"))
-			Expect(technology.GetCategoryForSkillName("POSTGRESQL")).To(Equal("database"))
-			Expect(technology.GetCategoryForSkillName("docker")).To(Equal("devops"))
+		It("should return security for security concepts", func() {
+			Expect(technology.GetCategoryForSkillName("Authentication")).To(Equal("security"))
+		})
+
+		It("should return practices for engineering practices", func() {
+			Expect(technology.GetCategoryForSkillName("TDD")).To(Equal("practices"))
+		})
+
+		It("should return security for OAuth (moved from tooling)", func() {
+			Expect(technology.GetCategoryForSkillName("OAuth")).To(Equal("security"))
+		})
+
+		It("should match multi-word keyword phrases", func() {
+			Expect(technology.GetCategoryForSkillName("domain-driven design")).To(Equal("architecture"))
+		})
+
+		It("should be case-insensitive", func() {
+			Expect(technology.GetCategoryForSkillName("DOCKER")).To(Equal("devops"))
 			Expect(technology.GetCategoryForSkillName("react")).To(Equal("frontend"))
 		})
 
-		It("should match keywords as well as canonical names", func() {
-			Expect(technology.GetCategoryForSkillName("golang")).To(Equal("backend"))
-			Expect(technology.GetCategoryForSkillName("postgres")).To(Equal("database"))
-			Expect(technology.GetCategoryForSkillName("k8s")).To(Equal("devops"))
-			Expect(technology.GetCategoryForSkillName("nodejs")).To(Equal("backend"))
+		It("should return empty string for unknown skills", func() {
+			Expect(technology.GetCategoryForSkillName("UnknownTech12345")).To(BeEmpty())
 		})
 
-		It("should return empty string for unknown skill names", func() {
-			Expect(technology.GetCategoryForSkillName("UnknownTechnology")).To(BeEmpty())
-			Expect(technology.GetCategoryForSkillName("FooBar")).To(BeEmpty())
-			Expect(technology.GetCategoryForSkillName("")).To(BeEmpty())
-		})
-	})
-
-	Describe("Aliases", func() {
-		It("should support golang -> Go alias", func() {
-			keywordMap := technology.GetKeywordMap()
-
-			golangKw := keywordMap["golang"]
-			goKw := keywordMap["go"]
-
-			Expect(golangKw.Skill).To(Equal("Go"))
-			Expect(goKw.Skill).To(Equal("Go"))
-			Expect(golangKw.Skill).To(Equal(goKw.Skill))
+		It("should return backend for Go", func() {
+			Expect(technology.GetCategoryForSkillName("Go")).To(Equal("backend"))
 		})
 
-		It("should support k8s -> Kubernetes alias", func() {
-			keywordMap := technology.GetKeywordMap()
-
-			k8s := keywordMap["k8s"]
-			kubernetes := keywordMap["kubernetes"]
-
-			Expect(k8s.Skill).To(Equal("Kubernetes"))
-			Expect(kubernetes.Skill).To(Equal("Kubernetes"))
-			Expect(k8s.Skill).To(Equal(kubernetes.Skill))
+		It("should return backend for C", func() {
+			Expect(technology.GetCategoryForSkillName("C")).To(Equal("backend"))
 		})
 
-		It("should support postgres -> PostgreSQL alias", func() {
-			keywordMap := technology.GetKeywordMap()
+		It("should return database for PostgreSQL", func() {
+			Expect(technology.GetCategoryForSkillName("PostgreSQL")).To(Equal("database"))
+		})
 
-			postgres := keywordMap["postgres"]
-			postgresql := keywordMap["postgresql"]
-
-			Expect(postgres.Skill).To(Equal("PostgreSQL"))
-			Expect(postgresql.Skill).To(Equal("PostgreSQL"))
+		It("should return cloud for AWS", func() {
+			Expect(technology.GetCategoryForSkillName("AWS")).To(Equal("cloud"))
 		})
 	})
 })

--- a/internal/service/career/technology/keywords_test.go
+++ b/internal/service/career/technology/keywords_test.go
@@ -255,5 +255,37 @@ var _ = Describe("Keywords", func() {
 		It("should return cloud for AWS", func() {
 			Expect(technology.GetCategoryForSkillName("AWS")).To(Equal("cloud"))
 		})
+
+		Context("substring matching fallback", func() {
+			It("should match when keyword is a substring of skill name", func() {
+				Expect(technology.GetCategoryForSkillName("ELK Stack")).To(Equal("monitoring"))
+			})
+
+			It("should match plural/suffix variants", func() {
+				Expect(technology.GetCategoryForSkillName("Code Reviews")).To(Equal("practices"))
+			})
+
+			It("should match keyword prefix in compound names", func() {
+				Expect(technology.GetCategoryForSkillName("Zend Framework")).To(Equal("backend"))
+			})
+
+			It("should match compound skill names with existing keywords", func() {
+				Expect(technology.GetCategoryForSkillName("REST API")).To(Equal("backend"))
+			})
+
+			It("should match hyphenated compound names", func() {
+				Expect(technology.GetCategoryForSkillName("Event-driven Architecture")).To(Equal("architecture"))
+			})
+
+			It("should not false-match short keywords inside unrelated words", func() {
+				Expect(technology.GetCategoryForSkillName("Communication")).To(BeEmpty())
+				Expect(technology.GetCategoryForSkillName("Logistics Systems")).To(BeEmpty())
+				Expect(technology.GetCategoryForSkillName("Career Development")).To(BeEmpty())
+			})
+
+			It("should still prefer exact match over substring match", func() {
+				Expect(technology.GetCategoryForSkillName("Docker")).To(Equal("devops"))
+			})
+		})
 	})
 })

--- a/internal/service/career/technology/keywords_test.go
+++ b/internal/service/career/technology/keywords_test.go
@@ -16,8 +16,8 @@ import (
 
 var _ = Describe("Keywords", func() {
 	Describe("Dictionary Structure", func() {
-		It("should have at least 350 keyword entries", func() {
-			Expect(len(technology.Keywords)).To(BeNumerically(">=", 350))
+		It("should have at least 480 keyword entries", func() {
+			Expect(len(technology.Keywords)).To(BeNumerically(">=", 480))
 		})
 
 		It("should only use canonical categories from constants.AllSkillCategories", func() {
@@ -68,7 +68,7 @@ var _ = Describe("Keywords", func() {
 		})
 
 		It("should have architecture keywords", func() {
-			Expect(categoryCounts["architecture"]).To(BeNumerically(">=", 25))
+			Expect(categoryCounts["architecture"]).To(BeNumerically(">=", 55))
 		})
 
 		It("should have security keywords", func() {
@@ -76,35 +76,35 @@ var _ = Describe("Keywords", func() {
 		})
 
 		It("should have practices keywords", func() {
-			Expect(categoryCounts["practices"]).To(BeNumerically(">=", 25))
+			Expect(categoryCounts["practices"]).To(BeNumerically(">=", 80))
 		})
 
 		It("should have backend keywords", func() {
-			Expect(categoryCounts["backend"]).To(BeNumerically(">=", 30))
+			Expect(categoryCounts["backend"]).To(BeNumerically(">=", 68))
 		})
 
 		It("should have frontend keywords", func() {
-			Expect(categoryCounts["frontend"]).To(BeNumerically(">=", 20))
+			Expect(categoryCounts["frontend"]).To(BeNumerically(">=", 50))
 		})
 
 		It("should have devops keywords", func() {
-			Expect(categoryCounts["devops"]).To(BeNumerically(">=", 20))
+			Expect(categoryCounts["devops"]).To(BeNumerically(">=", 38))
 		})
 
 		It("should have database keywords", func() {
-			Expect(categoryCounts["database"]).To(BeNumerically(">=", 14))
+			Expect(categoryCounts["database"]).To(BeNumerically(">=", 15))
 		})
 
 		It("should have testing keywords", func() {
-			Expect(categoryCounts["testing"]).To(BeNumerically(">=", 15))
+			Expect(categoryCounts["testing"]).To(BeNumerically(">=", 16))
 		})
 
 		It("should have monitoring keywords", func() {
-			Expect(categoryCounts["monitoring"]).To(BeNumerically(">=", 10))
+			Expect(categoryCounts["monitoring"]).To(BeNumerically(">=", 16))
 		})
 
 		It("should have data keywords", func() {
-			Expect(categoryCounts["data"]).To(BeNumerically(">=", 7))
+			Expect(categoryCounts["data"]).To(BeNumerically(">=", 12))
 		})
 
 		It("should have ml keywords", func() {
@@ -112,7 +112,7 @@ var _ = Describe("Keywords", func() {
 		})
 
 		It("should have tooling keywords", func() {
-			Expect(categoryCounts["tooling"]).To(BeNumerically(">=", 30))
+			Expect(categoryCounts["tooling"]).To(BeNumerically(">=", 34))
 		})
 	})
 
@@ -254,6 +254,79 @@ var _ = Describe("Keywords", func() {
 
 		It("should return cloud for AWS", func() {
 			Expect(technology.GetCategoryForSkillName("AWS")).To(Equal("cloud"))
+		})
+
+		Context("compound phrase lookups", func() {
+			It("should categorize architecture compound phrases", func() {
+				Expect(technology.GetCategoryForSkillName("Backend Architecture")).To(Equal("architecture"))
+				Expect(technology.GetCategoryForSkillName("Service Architecture")).To(Equal("architecture"))
+				Expect(technology.GetCategoryForSkillName("Component Architecture")).To(Equal("architecture"))
+				Expect(technology.GetCategoryForSkillName("Real-time Systems")).To(Equal("architecture"))
+				Expect(technology.GetCategoryForSkillName("Scalable Systems")).To(Equal("architecture"))
+				Expect(technology.GetCategoryForSkillName("Repository Pattern")).To(Equal("architecture"))
+				Expect(technology.GetCategoryForSkillName("Builder Pattern")).To(Equal("architecture"))
+				Expect(technology.GetCategoryForSkillName("ADR")).To(Equal("architecture"))
+			})
+
+			It("should categorize practices compound phrases", func() {
+				Expect(technology.GetCategoryForSkillName("Agile Delivery")).To(Equal("practices"))
+				Expect(technology.GetCategoryForSkillName("Project Management")).To(Equal("practices"))
+				Expect(technology.GetCategoryForSkillName("Software Engineering")).To(Equal("practices"))
+				Expect(technology.GetCategoryForSkillName("Engineering Practices")).To(Equal("practices"))
+				Expect(technology.GetCategoryForSkillName("Code Standards")).To(Equal("practices"))
+				Expect(technology.GetCategoryForSkillName("Technical Leadership")).To(Equal("practices"))
+				Expect(technology.GetCategoryForSkillName("Knowledge Transfer")).To(Equal("practices"))
+				Expect(technology.GetCategoryForSkillName("Collaboration")).To(Equal("practices"))
+			})
+
+			It("should categorize backend compound phrases", func() {
+				Expect(technology.GetCategoryForSkillName("Backend Development")).To(Equal("backend"))
+				Expect(technology.GetCategoryForSkillName("Full-stack Development")).To(Equal("backend"))
+				Expect(technology.GetCategoryForSkillName("Web Development")).To(Equal("backend"))
+				Expect(technology.GetCategoryForSkillName("API Development")).To(Equal("backend"))
+				Expect(technology.GetCategoryForSkillName("CRUD")).To(Equal("backend"))
+				Expect(technology.GetCategoryForSkillName("Error Handling")).To(Equal("backend"))
+			})
+
+			It("should categorize frontend compound phrases", func() {
+				Expect(technology.GetCategoryForSkillName("Component Library")).To(Equal("frontend"))
+				Expect(technology.GetCategoryForSkillName("Keyboard Navigation")).To(Equal("frontend"))
+				Expect(technology.GetCategoryForSkillName("Layout Design")).To(Equal("frontend"))
+				Expect(technology.GetCategoryForSkillName("UX")).To(Equal("frontend"))
+				Expect(technology.GetCategoryForSkillName("User Experience")).To(Equal("frontend"))
+				Expect(technology.GetCategoryForSkillName("Bubble Tea")).To(Equal("frontend"))
+				Expect(technology.GetCategoryForSkillName("Vite")).To(Equal("frontend"))
+			})
+
+			It("should categorize devops compound phrases", func() {
+				Expect(technology.GetCategoryForSkillName("Incident Response")).To(Equal("devops"))
+				Expect(technology.GetCategoryForSkillName("Production Support")).To(Equal("devops"))
+				Expect(technology.GetCategoryForSkillName("Embedded Systems")).To(Equal("devops"))
+				Expect(technology.GetCategoryForSkillName("Reliability Engineering")).To(Equal("devops"))
+				Expect(technology.GetCategoryForSkillName("Firmware Development")).To(Equal("devops"))
+			})
+
+			It("should categorize monitoring compound phrases", func() {
+				Expect(technology.GetCategoryForSkillName("Kibana")).To(Equal("monitoring"))
+				Expect(technology.GetCategoryForSkillName("Logstash")).To(Equal("monitoring"))
+			})
+
+			It("should categorize database compound phrases", func() {
+				Expect(technology.GetCategoryForSkillName("TimescaleDB")).To(Equal("database"))
+			})
+
+			It("should categorize tooling compound phrases", func() {
+				Expect(technology.GetCategoryForSkillName("Technical Writing")).To(Equal("tooling"))
+				Expect(technology.GetCategoryForSkillName("Diagramming")).To(Equal("tooling"))
+			})
+
+			It("should categorize data compound phrases", func() {
+				Expect(technology.GetCategoryForSkillName("Streaming")).To(Equal("data"))
+			})
+
+			It("should categorize testing compound phrases", func() {
+				Expect(technology.GetCategoryForSkillName("Playwright")).To(Equal("testing"))
+			})
 		})
 
 		Context("substring matching fallback", func() {

--- a/internal/service/career/technology/keywords_test.go
+++ b/internal/service/career/technology/keywords_test.go
@@ -359,6 +359,54 @@ var _ = Describe("Keywords", func() {
 			It("should still prefer exact match over substring match", func() {
 				Expect(technology.GetCategoryForSkillName("Docker")).To(Equal("devops"))
 			})
+
+			It("should match keyword at second occurrence when first fails boundary", func() {
+				Expect(technology.GetCategoryForSkillName("norest rest")).To(Equal("backend"))
+			})
+		})
+
+		Context("short keyword safety for ai", func() {
+			It("should not false-match ai inside Maintaining", func() {
+				Expect(technology.GetCategoryForSkillName("Maintaining")).To(BeEmpty())
+			})
+
+			It("should not false-match ai inside Email", func() {
+				Expect(technology.GetCategoryForSkillName("Email")).To(BeEmpty())
+			})
+
+			It("should match AI as standalone skill", func() {
+				Expect(technology.GetCategoryForSkillName("AI")).To(Equal("ml"))
+			})
+		})
+
+		Context("short keyword safety for r", func() {
+			It("should match R as standalone skill", func() {
+				Expect(technology.GetCategoryForSkillName("R")).To(Equal("backend"))
+			})
+
+			It("should not false-match r inside Career Development", func() {
+				Expect(technology.GetCategoryForSkillName("Career Development")).To(BeEmpty())
+			})
+		})
+
+		Context("broad keyword priority", func() {
+			It("should categorize Database Design as database not practices", func() {
+				Expect(technology.GetCategoryForSkillName("Database Design")).NotTo(Equal("practices"))
+			})
+
+			It("should categorize Performance Testing as testing not practices", func() {
+				Expect(technology.GetCategoryForSkillName("Performance Testing")).To(Equal("testing"))
+			})
+
+			It("should categorize Data Processing as data not practices", func() {
+				Expect(technology.GetCategoryForSkillName("Data Processing")).To(Equal("data"))
+			})
+		})
+
+		Context("Swift category", func() {
+			It("should categorize Swift as mobile", func() {
+				Expect(technology.GetCategoryForSkillName("Swift")).To(Equal("mobile"))
+			})
 		})
 	})
 })

--- a/internal/service/career/technology/keywords_test.go
+++ b/internal/service/career/technology/keywords_test.go
@@ -1,10 +1,15 @@
 package technology_test
 
 import (
+	"context"
 	"strings"
 
 	"github.com/baphled/kariya/internal/constants"
+	career "github.com/baphled/kariya/internal/domain/career"
+	careerRepo "github.com/baphled/kariya/internal/repository/career"
+	careermemory "github.com/baphled/kariya/internal/repository/career/memory"
 	"github.com/baphled/kariya/internal/service/career/technology"
+	"github.com/baphled/kariya/internal/testutil/fixtures"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -12,7 +17,7 @@ import (
 var _ = Describe("Keywords", func() {
 	Describe("Dictionary Structure", func() {
 		It("should have at least 350 keyword entries", func() {
-			Expect(len(technology.TechnologyKeywords)).To(BeNumerically(">=", 350))
+			Expect(len(technology.Keywords)).To(BeNumerically(">=", 350))
 		})
 
 		It("should only use canonical categories from constants.AllSkillCategories", func() {
@@ -22,7 +27,7 @@ var _ = Describe("Keywords", func() {
 				validCategories[string(cat)] = true
 			}
 
-			for _, kw := range technology.TechnologyKeywords {
+			for _, kw := range technology.Keywords {
 				Expect(validCategories).To(HaveKey(kw.Category),
 					"keyword %q uses invalid category %q", kw.Keyword, kw.Category)
 			}
@@ -30,7 +35,7 @@ var _ = Describe("Keywords", func() {
 
 		It("should have no duplicate keywords", func() {
 			seen := make(map[string]bool)
-			for _, kw := range technology.TechnologyKeywords {
+			for _, kw := range technology.Keywords {
 				Expect(seen).NotTo(HaveKey(kw.Keyword),
 					"duplicate keyword: %q", kw.Keyword)
 				seen[kw.Keyword] = true
@@ -38,14 +43,14 @@ var _ = Describe("Keywords", func() {
 		})
 
 		It("should have all keywords in lowercase", func() {
-			for _, kw := range technology.TechnologyKeywords {
+			for _, kw := range technology.Keywords {
 				Expect(kw.Keyword).To(Equal(strings.ToLower(kw.Keyword)),
 					"keyword %q should be lowercase", kw.Keyword)
 			}
 		})
 
 		It("should have non-empty skill names", func() {
-			for _, kw := range technology.TechnologyKeywords {
+			for _, kw := range technology.Keywords {
 				Expect(kw.Skill).NotTo(BeEmpty(),
 					"keyword %q has empty skill name", kw.Keyword)
 			}
@@ -57,7 +62,7 @@ var _ = Describe("Keywords", func() {
 
 		BeforeEach(func() {
 			categoryCounts = make(map[string]int)
-			for _, kw := range technology.TechnologyKeywords {
+			for _, kw := range technology.Keywords {
 				categoryCounts[kw.Category]++
 			}
 		})
@@ -108,6 +113,100 @@ var _ = Describe("Keywords", func() {
 
 		It("should have tooling keywords", func() {
 			Expect(categoryCounts["tooling"]).To(BeNumerically(">=", 30))
+		})
+	})
+
+	Describe("RecategorizeSkills", func() {
+		var skillRepo careerRepo.SkillRepository
+
+		BeforeEach(func() {
+			skillRepo = careermemory.NewSkillRepository()
+		})
+
+		It("should return zero changes for an empty repository", func() {
+			result, err := technology.RecategorizeSkills(context.Background(), skillRepo)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Total).To(Equal(0))
+			Expect(result.Updated).To(Equal(0))
+		})
+
+		It("should recategorize skills with matching keywords", func() {
+			ctx := context.Background()
+			skill := fixtures.SkillWith("s1", "Docker", "other", "intermediate")
+			Expect(skillRepo.Create(ctx, skill)).To(Succeed())
+
+			result, err := technology.RecategorizeSkills(ctx, skillRepo)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Updated).To(Equal(1))
+			Expect(result.ByCategory).To(HaveKeyWithValue("devops", 1))
+
+			updated, err := skillRepo.GetByID(ctx, skill.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated.Category).To(Equal("devops"))
+		})
+
+		It("should skip skills that already have the correct category", func() {
+			ctx := context.Background()
+			skill := fixtures.SkillWith("s1", "Docker", "devops", "intermediate")
+			Expect(skillRepo.Create(ctx, skill)).To(Succeed())
+
+			result, err := technology.RecategorizeSkills(ctx, skillRepo)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Updated).To(Equal(0))
+			Expect(result.Skipped).To(Equal(1))
+		})
+
+		It("should skip skills with no keyword match", func() {
+			ctx := context.Background()
+			skill := fixtures.SkillWith("s1", "UnknownTechnology12345", "other", "intermediate")
+			Expect(skillRepo.Create(ctx, skill)).To(Succeed())
+
+			result, err := technology.RecategorizeSkills(ctx, skillRepo)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Updated).To(Equal(0))
+			Expect(result.NoMatch).To(Equal(1))
+		})
+
+		It("should handle multiple skills across categories", func() {
+			ctx := context.Background()
+			skills := []*career.Skill{
+				fixtures.SkillWith("s1", "React", "other", "advanced"),
+				fixtures.SkillWith("s2", "PostgreSQL", "other", "advanced"),
+				fixtures.SkillWith("s3", "TDD", "other", "advanced"),
+				fixtures.SkillWith("s4", "Go", "backend", "expert"),
+			}
+			for _, s := range skills {
+				Expect(skillRepo.Create(ctx, s)).To(Succeed())
+			}
+
+			result, err := technology.RecategorizeSkills(ctx, skillRepo)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Total).To(Equal(4))
+			Expect(result.Updated).To(Equal(3))
+			Expect(result.Skipped).To(Equal(1))
+			Expect(result.ByCategory).To(HaveKeyWithValue("frontend", 1))
+			Expect(result.ByCategory).To(HaveKeyWithValue("database", 1))
+			Expect(result.ByCategory).To(HaveKeyWithValue("practices", 1))
+		})
+
+		It("should move OAuth from tooling to security", func() {
+			ctx := context.Background()
+			skill := fixtures.SkillWith("s1", "OAuth", "tooling", "intermediate")
+			Expect(skillRepo.Create(ctx, skill)).To(Succeed())
+
+			result, err := technology.RecategorizeSkills(ctx, skillRepo)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Updated).To(Equal(1))
+
+			updated, err := skillRepo.GetByID(ctx, skill.ID)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated.Category).To(Equal("security"))
 		})
 	})
 

--- a/internal/testutil/e2e/fixtures.go
+++ b/internal/testutil/e2e/fixtures.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/baphled/kariya/internal/constants"
 	"github.com/baphled/kariya/internal/domain/career"
 )
 
@@ -290,4 +291,85 @@ func CreateMinimalFact(id string, sourceEventID string) *career.Fact {
 		CreatedAt:            now,
 		UpdatedAt:            now,
 	}
+}
+
+// CreateMinimalSkill creates a single minimal valid skill for testing.
+func CreateMinimalSkill(id, name, category string) *career.Skill {
+	now := time.Now()
+	return &career.Skill{
+		ID:        id,
+		Name:      name,
+		Category:  category,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
+// skillFixtureDef pairs a representative skill name with its category constant.
+type skillFixtureDef struct {
+	Name     string
+	Category constants.SkillCategory
+	Level    string
+}
+
+// allSkillFixtureDefs returns one representative skill per category, derived
+// from constants.AllSkillCategories so fixtures stay in sync with the
+// canonical category list.
+func allSkillFixtureDefs() []skillFixtureDef {
+	nameForCategory := map[constants.SkillCategory]struct {
+		Name  string
+		Level string
+	}{
+		constants.SkillCategoryBackend:      {"Go", "expert"},
+		constants.SkillCategoryFrontend:     {"React", "advanced"},
+		constants.SkillCategoryDevOps:       {"Docker", "advanced"},
+		constants.SkillCategoryDatabase:     {"PostgreSQL", "expert"},
+		constants.SkillCategoryCloud:        {"AWS", "intermediate"},
+		constants.SkillCategoryMobile:       {"Swift", "beginner"},
+		constants.SkillCategoryTooling:      {"Git", "expert"},
+		constants.SkillCategoryTesting:      {"Ginkgo", "advanced"},
+		constants.SkillCategoryData:         {"Apache Kafka", "intermediate"},
+		constants.SkillCategoryML:           {"TensorFlow", "beginner"},
+		constants.SkillCategoryMonitoring:   {"Prometheus", "intermediate"},
+		constants.SkillCategoryArchitecture: {"Microservices", "advanced"},
+		constants.SkillCategorySecurity:     {"OAuth", "intermediate"},
+		constants.SkillCategoryPractices:    {"Agile", "expert"},
+		constants.SkillCategoryOther:        {"IRC", "beginner"},
+	}
+
+	defs := make([]skillFixtureDef, 0, len(constants.AllSkillCategories()))
+	for _, cat := range constants.AllSkillCategories() {
+		info := nameForCategory[cat]
+		defs = append(defs, skillFixtureDef{
+			Name:     info.Name,
+			Category: cat,
+			Level:    info.Level,
+		})
+	}
+	return defs
+}
+
+// CreateSampleSkills generates test skills across all categories.
+// The returned skills derive their categories from constants.AllSkillCategories
+// so the fixture data stays in sync with the canonical category list.
+func CreateSampleSkills(count int) []*career.Skill {
+	defs := allSkillFixtureDefs()
+
+	skills := make([]*career.Skill, 0, count)
+	now := time.Now()
+
+	for i := 0; i < count && i < len(defs); i++ {
+		def := defs[i]
+		skill := &career.Skill{
+			ID:        fmt.Sprintf("skill-%03d", i+1),
+			Name:      def.Name,
+			Category:  string(def.Category),
+			Level:     def.Level,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		skills = append(skills, skill)
+	}
+
+	return skills
 }

--- a/internal/testutil/e2e/helpers.go
+++ b/internal/testutil/e2e/helpers.go
@@ -972,6 +972,53 @@ func (e *TestEnv) GetFacts() []*career.Fact {
 	return facts
 }
 
+// GetSkills returns all skills from the database.
+func (e *TestEnv) GetSkills() []*career.Skill {
+	e.T.Helper()
+
+	skillRepo := e.Service.GetSkillRepository()
+	if skillRepo == nil {
+		e.T.Fatal("skill repository not set")
+	}
+
+	skills, err := skillRepo.List(e.Ctx, nil)
+	if err != nil {
+		e.T.Fatalf("failed to get skills: %v", err)
+	}
+
+	return skills
+}
+
+// AssertSkillCount verifies the number of skills in the database.
+func (e *TestEnv) AssertSkillCount(expected int) *TestEnv {
+	e.T.Helper()
+
+	skills := e.GetSkills()
+
+	if len(skills) != expected {
+		e.T.Errorf("expected %d skills, got %d", expected, len(skills))
+	}
+
+	return e
+}
+
+// AddSkill creates a skill in the database.
+func (e *TestEnv) AddSkill(skill *career.Skill) *TestEnv {
+	e.T.Helper()
+
+	skillRepo := e.Service.GetSkillRepository()
+	if skillRepo == nil {
+		e.T.Fatal("skill repository not set")
+	}
+
+	err := skillRepo.Create(e.Ctx, skill)
+	if err != nil {
+		e.T.Fatalf("failed to create skill: %v", err)
+	}
+
+	return e
+}
+
 // ============================================================================
 // Session Simulation
 // ============================================================================

--- a/internal/testutil/e2e/skills_management_e2e_test.go
+++ b/internal/testutil/e2e/skills_management_e2e_test.go
@@ -1,0 +1,225 @@
+package e2e_test
+
+import (
+	"fmt"
+
+	"github.com/baphled/kariya/internal/constants"
+	"github.com/baphled/kariya/internal/testutil/e2e"
+	tea "github.com/charmbracelet/bubbletea"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("E2E SkillsManagement Workflow", func() {
+	var env *e2e.TestEnv
+
+	Describe("Empty Skill List", func() {
+		BeforeEach(func() {
+			env = e2e.GetSharedEnv(GinkgoT())
+		})
+
+		AfterEach(func() {
+			env.Cleanup()
+		})
+
+		It("should show empty message when no skills exist", func() {
+			env.AssertSkillCount(0)
+			env.SelectIntentByName("manage_skills")
+			view := env.GetView()
+			Expect(view).NotTo(BeEmpty())
+		})
+
+		It("should not panic on empty skill list", func() {
+			env.SelectIntentByName("manage_skills")
+			view := env.GetView()
+			Expect(view).NotTo(BeEmpty())
+			Expect(view).NotTo(ContainSubstring("panic"))
+		})
+
+		It("should allow navigation back from empty list", func() {
+			env.SelectIntentByName("manage_skills")
+			env.Cancel()
+			env.AssertViewContains("Capture Event")
+		})
+	})
+
+	Describe("Skill Persistence with New Categories", func() {
+		BeforeEach(func() {
+			env = e2e.GetSharedEnv(GinkgoT())
+		})
+
+		AfterEach(func() {
+			env.Cleanup()
+		})
+
+		It("should persist skills with architecture category", func() {
+			skill := e2e.CreateMinimalSkill("s-arch", "Microservices", string(constants.SkillCategoryArchitecture))
+			env.AddSkill(skill)
+			env.AssertSkillCount(1)
+
+			skills := env.GetSkills()
+			Expect(skills[0].Category).To(Equal(string(constants.SkillCategoryArchitecture)))
+		})
+
+		It("should persist skills with security category", func() {
+			skill := e2e.CreateMinimalSkill("s-sec", "OAuth", string(constants.SkillCategorySecurity))
+			env.AddSkill(skill)
+			env.AssertSkillCount(1)
+
+			skills := env.GetSkills()
+			Expect(skills[0].Category).To(Equal(string(constants.SkillCategorySecurity)))
+		})
+
+		It("should persist skills with practices category", func() {
+			skill := e2e.CreateMinimalSkill("s-prac", "Agile", string(constants.SkillCategoryPractices))
+			env.AddSkill(skill)
+			env.AssertSkillCount(1)
+
+			skills := env.GetSkills()
+			Expect(skills[0].Category).To(Equal(string(constants.SkillCategoryPractices)))
+		})
+
+		It("should persist skills across all 15 categories", func() {
+			allCategories := constants.AllSkillCategories()
+			Expect(allCategories).To(HaveLen(15))
+
+			for i, cat := range allCategories {
+				skill := e2e.CreateMinimalSkill(
+					fmt.Sprintf("s-%02d", i),
+					fmt.Sprintf("Skill_%s", string(cat)),
+					string(cat),
+				)
+				env.AddSkill(skill)
+			}
+
+			env.AssertSkillCount(15)
+
+			skills := env.GetSkills()
+			persistedCategories := make(map[string]bool)
+			for _, s := range skills {
+				persistedCategories[s.Category] = true
+			}
+
+			for _, cat := range allCategories {
+				Expect(persistedCategories).To(HaveKey(string(cat)),
+					"category %q should be persisted", string(cat))
+			}
+		})
+	})
+
+	Describe("Sample Skills Fixture", func() {
+		BeforeEach(func() {
+			env = e2e.GetSharedEnv(GinkgoT())
+		})
+
+		AfterEach(func() {
+			env.Cleanup()
+		})
+
+		It("should create sample skills covering all categories", func() {
+			allCategories := constants.AllSkillCategories()
+			skills := e2e.CreateSampleSkills(len(allCategories))
+			Expect(skills).To(HaveLen(len(allCategories)))
+
+			coveredCategories := make(map[string]bool)
+			for _, s := range skills {
+				coveredCategories[s.Category] = true
+			}
+
+			for _, cat := range allCategories {
+				Expect(coveredCategories).To(HaveKey(string(cat)),
+					"CreateSampleSkills should cover category %q", string(cat))
+			}
+		})
+
+		It("should persist sample skills to database", func() {
+			allCategories := constants.AllSkillCategories()
+			skills := e2e.CreateSampleSkills(len(allCategories))
+			for _, s := range skills {
+				env.AddSkill(s)
+			}
+
+			env.AssertSkillCount(len(allCategories))
+		})
+	})
+
+	Describe("Skills Management Navigation", func() {
+		BeforeEach(func() {
+			env = e2e.GetSharedEnv(GinkgoT())
+			skills := e2e.CreateSampleSkills(5)
+			for _, s := range skills {
+				env.AddSkill(s)
+			}
+		})
+
+		AfterEach(func() {
+			env.Cleanup()
+		})
+
+		It("should navigate to manage skills intent", func() {
+			env.SelectIntentByName("manage_skills")
+			view := env.GetView()
+			Expect(view).NotTo(BeEmpty())
+			Expect(view).To(ContainSubstring("Skills"))
+		})
+
+		It("should navigate down with j key", func() {
+			env.SelectIntentByName("manage_skills")
+			env.PressKeyRune('j')
+			view := env.GetView()
+			Expect(view).NotTo(BeEmpty())
+		})
+
+		It("should navigate with arrow keys", func() {
+			env.SelectIntentByName("manage_skills")
+			env.PressKey(tea.KeyDown)
+			view := env.GetView()
+			Expect(view).NotTo(BeEmpty())
+			env.PressKey(tea.KeyUp)
+			view = env.GetView()
+			Expect(view).NotTo(BeEmpty())
+		})
+
+		It("should return to menu on escape", func() {
+			env.SelectIntentByName("manage_skills")
+			env.Cancel()
+			env.AssertViewContains("Capture Event")
+		})
+	})
+
+	Describe("Category Validation via Constants", func() {
+		It("should validate all new categories as valid", func() {
+			Expect(constants.IsValidSkillCategory("architecture")).To(BeTrue())
+			Expect(constants.IsValidSkillCategory("security")).To(BeTrue())
+			Expect(constants.IsValidSkillCategory("practices")).To(BeTrue())
+		})
+
+		It("should validate all original categories as valid", func() {
+			Expect(constants.IsValidSkillCategory("backend")).To(BeTrue())
+			Expect(constants.IsValidSkillCategory("frontend")).To(BeTrue())
+			Expect(constants.IsValidSkillCategory("devops")).To(BeTrue())
+			Expect(constants.IsValidSkillCategory("database")).To(BeTrue())
+			Expect(constants.IsValidSkillCategory("cloud")).To(BeTrue())
+			Expect(constants.IsValidSkillCategory("mobile")).To(BeTrue())
+			Expect(constants.IsValidSkillCategory("tooling")).To(BeTrue())
+			Expect(constants.IsValidSkillCategory("testing")).To(BeTrue())
+			Expect(constants.IsValidSkillCategory("data")).To(BeTrue())
+			Expect(constants.IsValidSkillCategory("ml")).To(BeTrue())
+			Expect(constants.IsValidSkillCategory("monitoring")).To(BeTrue())
+			Expect(constants.IsValidSkillCategory("other")).To(BeTrue())
+		})
+
+		It("should reject invalid categories", func() {
+			Expect(constants.IsValidSkillCategory("invalid")).To(BeFalse())
+			Expect(constants.IsValidSkillCategory("")).To(BeFalse())
+		})
+
+		It("should produce string representations for all 15 categories", func() {
+			strs := constants.SkillCategoryStrings()
+			Expect(strs).To(HaveLen(15))
+			Expect(strs).To(ContainElements(
+				"architecture", "security", "practices",
+			))
+		})
+	})
+})

--- a/tasks/tasks-54-enhance-skill-categorization.md
+++ b/tasks/tasks-54-enhance-skill-categorization.md
@@ -204,15 +204,17 @@ Logistics Systems, Marketing, ShoutCast, WAP.
 
 ## Commit Strategy
 
-7 atomic commits:
+9 atomic commits:
 
 1. `feat(domain): add architecture, security, practices skill categories` — DONE
 2. `feat(service): add keyword dictionary with 350 entries` — DONE
 3. `feat(cli): add --recategorize-skills flag` — DONE
 4. `feat(cv): update profile inference for new categories` — DONE
 5. `fix(service): add substring matching fallback to keyword lookup` — DONE
-6. `feat(service): expand keyword dictionary with compound phrase entries` — DONE
-7. `docs(tasks): update task 54 status after final validation` — DONE
+6. `docs(tasks): add task 54 spec` — DONE
+7. `feat(service): expand keyword dictionary with compound phrase entries` — DONE
+8. `docs(tasks): update task 54 status after final validation` — DONE
+9. `fix(service): address PR review feedback on keyword safety and matching` — DONE
 
 ## Risks & Notes
 

--- a/tasks/tasks-54-enhance-skill-categorization.md
+++ b/tasks/tasks-54-enhance-skill-categorization.md
@@ -7,7 +7,7 @@ dictionary in `keywords.go` only covers ~224 exact technology tool/framework
 names. Imported skills include practices, architectural patterns, security
 concepts, and engineering methodologies that have no keyword entries.
 
-### Current Distribution
+### Original Distribution (before any work)
 
 | Category   | Count | % of Total |
 |------------|------:|----------:|
@@ -24,20 +24,59 @@ concepts, and engineering methodologies that have no keyword entries.
 | data       |     0 |      0.0% |
 | ml         |     0 |      0.0% |
 
+### Post-Phase 1-4 Distribution (after first recategorization run)
+
+| Category     | Count | % of Total |
+|--------------|------:|----------:|
+| other        |   167 |     54.8% |
+| backend      |    20 |      6.6% |
+| devops       |    15 |      4.9% |
+| frontend     |    15 |      4.9% |
+| practices    |    14 |      4.6% |
+| database     |    13 |      4.3% |
+| architecture |    10 |      3.3% |
+| testing      |    10 |      3.3% |
+| monitoring   |     9 |      3.0% |
+| security     |     9 |      3.0% |
+| tooling      |     9 |      3.0% |
+| data         |     8 |      2.6% |
+| ml           |     4 |      1.3% |
+| cloud        |     2 |      0.7% |
+
+**167 skills remain "other".** Analysis reveals two root causes:
+
+1. **Exact-match-only algorithm** — `GetCategoryForSkillName` requires the
+   entire skill name to match a keyword exactly after lowercasing. "ELK Stack"
+   does not match keyword `"elk"`, "Code Reviews" does not match `"code review"`.
+2. **Missing keywords for compound phrases** — Skills like "Backend Development",
+   "Service Architecture", "Component Library" are multi-word phrases absent
+   from the dictionary.
+
+### Breakdown of 167 Remaining "Other" Skills
+
+| Bucket | Count | Fix Required |
+|--------|------:|--------------|
+| Exact match exists, missed due to bug | 6 | Add missing keywords (`timescaledb`, `kibana`, `logstash`) |
+| Substring match would work | 9 | Improve matching algorithm (contains fallback) |
+| Need new keywords | 124 | Add ~124 keyword entries for compound phrases |
+| Genuinely uncategorizable | 28 | Correct — remain as "other" |
+
 ## Goal
 
-Reduce "other" from 84% to ~28% by:
+Reduce "other" from 84% to ~9% by:
 
 1. Adding 3 new `SkillCategory` constants: `architecture`, `security`,
    `practices`.
-2. Expanding the keyword dictionary with ~130 new entries.
+2. Expanding the keyword dictionary with ~350 entries (initial) + ~130 more.
 3. Adding a `--recategorize-skills` CLI flag to update existing DB skills.
+4. Improving the matching algorithm with substring/contains fallback.
+5. Adding ~124 new compound-phrase keyword entries.
 
 ## Phases
 
 ### Phase 1: New SkillCategory Constants
 
-**Status:** NOT STARTED
+**Status:** DONE (commit `49bc64e4`)
 
 **Files:**
 
@@ -46,16 +85,77 @@ Reduce "other" from 84% to ~28% by:
 
 **Changes:**
 
-- Add `SkillCategoryArchitecture SkillCategory = "architecture"`.
-- Add `SkillCategorySecurity SkillCategory = "security"`.
-- Add `SkillCategoryPractices SkillCategory = "practices"`.
-- Update `AllSkillCategories()` to return 15 (currently 12).
-- `IsValidSkillCategory()` works automatically via `AllSkillCategories`.
+- Added `SkillCategoryArchitecture`, `SkillCategorySecurity`, `SkillCategoryPractices`.
+- Added `AllSkillCategories()`, `IsValidSkillCategory()`, `SkillCategoryStrings()`.
+- Total categories: 15 (was 8).
 
-**No other files need changes.** Domain validation in `skill.go` already calls
-`constants.IsValidSkillCategory()`.
+### Phase 2: Initial Keyword Dictionary
 
-### Phase 2: Expand Keyword Dictionary
+**Status:** DONE (commit `05fa5227`)
+
+**Files:**
+
+- `internal/service/career/technology/keywords.go`
+- `internal/service/career/technology/keywords_test.go`
+
+**Changes:**
+
+- Created `Entry` struct, `Keywords` slice (350 entries), `GetCategoryForSkillName()`.
+- OAuth moved from `tooling` to `security`.
+- 44 tests covering dictionary structure, coverage per category, lookup behavior.
+
+### Phase 3: Recategorization CLI Flag
+
+**Status:** DONE (commit `6a16ca04`)
+
+**Files:**
+
+- `cmd/cli/main.go`
+- `cmd/cli/main_test.go`
+- `internal/service/career/technology/keywords.go` (added `RecategorizeSkills`)
+
+**Changes:**
+
+- Added `RecategorizeResult` struct and `RecategorizeSkills(ctx, repo)` function.
+- Added `--recategorize-skills` CLI flag with summary output.
+- 6 unit tests + 3 CLI tests.
+
+### Phase 4: Update CV Profile Inference
+
+**Status:** DONE (commit `eabaaf94`)
+
+**Files:**
+
+- `internal/service/career/cv/profile_inference.go`
+- `internal/service/career/cv/profile_inference_test.go`
+
+**Changes:**
+
+- Routed `architecture` and `security` to Systems bucket in `InferTechnologies()`.
+- Added expertise checks for architecture and security in `InferCoreStrengths()`.
+- 4 new tests.
+
+### Phase 5: Improve Matching Algorithm
+
+**Status:** IN PROGRESS
+
+**Files:**
+
+- `internal/service/career/technology/keywords.go`
+- `internal/service/career/technology/keywords_test.go`
+
+**Problem:** `GetCategoryForSkillName` uses exact match only. "ELK Stack"
+lowercases to `"elk stack"` but the keyword is `"elk"`.
+
+**Fix:** Add a substring/contains fallback after exact match fails. Must
+guard against short keywords (`"c"`, `"r"`, `"go"`, `"ai"`) matching inside
+unrelated words — only apply substring matching for keywords >= 3 characters,
+or use word-boundary matching.
+
+**Also add missing exact keywords:** `timescaledb`, `kibana`, `logstash`,
+`bubble tea`, `lipgloss`, `cms`, `websocket` (singular).
+
+### Phase 6: Expand Keyword Dictionary for Compound Phrases
 
 **Status:** NOT STARTED
 
@@ -64,105 +164,58 @@ Reduce "other" from 84% to ~28% by:
 - `internal/service/career/technology/keywords.go`
 - `internal/service/career/technology/keywords_test.go`
 
-**New keyword sections (~130 entries):**
+**~124 new keywords needed for compound phrases like:**
 
-| Category       | Count | Examples                                                     |
-|----------------|------:|--------------------------------------------------------------|
-| architecture   |   ~30 | microservices, soa, domain-driven design, distributed systems, system design, scalability, dependency injection, state machine |
-| security       |   ~12 | security, authentication, tls, pki, pci, saml, active directory, compliance, encryption |
-| practices      |   ~30 | agile, tdd, bdd, code review, pair programming, refactoring, code quality, debugging, performance optimization, feature flags |
-| backend        |   ~15 | c, c++, coffeescript, zend, wordpress, sidekiq, ajax, soap, api, api design, websockets |
-| frontend       |    ~8 | backbonejs, responsive design, accessibility, storybook, seo, design systems, visual design |
-| devops         |   ~10 | deployment, infrastructure, server management, system administration, shell, cron, git flow, git hooks, operations, networking |
-| database       |    ~6 | nosql, database migrations, database optimization, database performance, data modeling, data integrity |
-| testing        |    ~8 | ginkgo, gomega, e2e testing, automated testing, testing, code coverage, quality assurance |
-| monitoring     |    ~7 | logging, structured logging, alerting, metrics, observability, monitoring, elk |
-| data           |    ~7 | etl, data processing, data export, data platforms, analytics, business intelligence, reporting |
-| ml             |    ~4 | ai, generative ai, llms, prompt engineering |
-| tooling        |    ~6 | documentation, technical documentation, markdown, xml, json, csv |
+| Category     | Count | Examples |
+|--------------|------:|---------|
+| architecture | ~25   | backend architecture, component architecture, service architecture, asynchronous processing, real-time systems, scalable systems |
+| practices    | ~55   | agile delivery, code standards, collaboration, consulting, delivery management, engineering practices, project management, software engineering |
+| backend      | ~15   | backend development, backend engineering, crud, error handling, full-stack development, web development, serialization |
+| frontend     | ~15   | component library, form components, keyboard navigation, layout design, modal design, ux, user experience |
+| devops       | ~10   | firmware development, incident response, operational support, production support, reliability engineering |
+| tooling      | ~2    | diagramming, technical writing |
+| data         | ~1    | streaming |
 
-**Decision:** Move OAuth from `tooling` to `security` (authentication protocol).
-
-### Phase 3: Recategorization CLI Flag
-
-**Status:** NOT STARTED
-
-**Files:**
-
-- `cmd/cli/main.go`
-- `cmd/cli/main_test.go`
-- `internal/service/career/technology/keywords.go` (add `RecategorizeSkills`)
-
-**CLI usage:**
-
-```
-kariya --recategorize-skills                    # Default DB
-kariya --recategorize-skills --db ./events.db   # Custom DB
-```
-
-**Logic for `RecategorizeSkills(ctx, repo)`:**
-
-1. Load all skills via `repo.List(ctx, nil)`.
-2. For each skill call `GetCategoryForSkillName(skill.Name)`.
-3. If result is non-empty AND differs from current category, update via
-   `repo.Update(ctx, skill)`.
-4. Print summary: `Recategorized N skills (X backend, Y architecture, ...)`.
-5. Skip skills where `GetCategoryForSkillName` returns empty (no match).
-
-Exits after recategorization (does not launch TUI).
-
-### Phase 4: Update CV Profile Inference
-
-**Status:** NOT STARTED
-
-**Files:**
-
-- `internal/service/career/cv/profile_inference.go`
-
-Add awareness of new categories in the skill categorization switch:
-
-- `architecture` counts toward technical/backend weight.
-- `security` counts toward technical weight.
-- `practices` counts toward general technical weight.
-
-### Phase 5: Validation & Cleanup
+### Phase 7: Final Validation
 
 **Status:** NOT STARTED
 
 - `go test ./... -count=1` passes.
 - `staticcheck ./...` no new warnings.
-- `make check-compliance` passes (minus pre-existing violations).
 - Run `kariya --recategorize-skills` against actual DB.
-- Verify: `sqlite3 ~/.kariya/events.db "SELECT category, COUNT(*) FROM skills GROUP BY category ORDER BY count DESC;"`.
+- Verify distribution: `sqlite3 ~/.kariya/events.db "SELECT category, COUNT(*) FROM skills GROUP BY category ORDER BY count DESC;"`.
+- Target: ~28 skills remain "other" (genuinely uncategorizable).
 
-## Expected Outcome
+## Expected Final Outcome
 
-| Category        | Before | After |
-|-----------------|-------:|------:|
-| other           |    257 |   ~85 |
-| practices (new) |      0 |   ~34 |
-| architecture (new) |   0 |   ~30 |
-| backend         |      7 |   ~22 |
-| frontend        |      9 |   ~17 |
-| devops          |      7 |   ~17 |
-| database        |      8 |   ~14 |
-| tooling         |      8 |   ~13 |
-| testing         |      4 |   ~12 |
-| security (new)  |      0 |   ~10 |
-| monitoring      |      3 |   ~10 |
-| data            |      0 |    ~7 |
-| ml              |      0 |    ~4 |
-| cloud           |      2 |    ~3 |
+| Category     | Before | After Phase 4 | After Phase 7 |
+|--------------|-------:|--------------:|--------------:|
+| other        |    257 |           167 |           ~28 |
+| practices    |      0 |            14 |           ~69 |
+| architecture |      0 |            10 |           ~35 |
+| backend      |      7 |            20 |           ~35 |
+| frontend     |      9 |            15 |           ~30 |
+| devops       |      7 |            15 |           ~25 |
+| database     |      8 |            13 |           ~13 |
+| testing      |      4 |            10 |           ~10 |
+| monitoring   |      3 |             9 |           ~12 |
+| security     |      0 |             9 |            ~9 |
+| tooling      |      8 |             9 |           ~11 |
+| data         |      0 |             8 |            ~9 |
+| ml           |      0 |             4 |            ~4 |
+| cloud        |      2 |             2 |            ~2 |
 
 ## Commit Strategy
 
-4-5 atomic commits:
+7 atomic commits:
 
-1. `feat(constants): add architecture, security, practices skill categories`
-2. `feat(technology): expand keyword dictionary with ~130 entries`
-3. `feat(cli): add --recategorize-skills flag for existing skill migration`
-4. `feat(cv): update profile inference for new skill categories`
-5. `test: validate full recategorization flow`
+1. `feat(domain): add architecture, security, practices skill categories` — DONE
+2. `feat(service): add keyword dictionary with 350 entries` — DONE
+3. `feat(cli): add --recategorize-skills flag` — DONE
+4. `feat(cv): update profile inference for new categories` — DONE
+5. `fix(service): add substring matching fallback to keyword lookup`
+6. `feat(service): expand keyword dictionary with compound phrase entries`
+7. `docs(tasks): update task 54 status after final validation`
 
 ## Risks & Notes
 
@@ -172,7 +225,10 @@ Add awareness of new categories in the skill categorization switch:
   not an enum. New values work immediately.
 - **CV rendering:** `buildGroupedSkills` dynamically groups by category string.
   New categories appear automatically with no renderer changes.
-- **~85 skills remain "other":** These are genuinely uncategorizable (soft
+- **Short keyword safety:** Substring matching must not allow 1-2 char keywords
+  (`"c"`, `"r"`, `"go"`, `"ai"`) to match inside unrelated words. Use a minimum
+  keyword length threshold or word-boundary matching.
+- **~28 skills remain "other":** These are genuinely uncategorizable (soft
   skills, domain knowledge, niche tech like IRC/WAP/ShoutCast). Acceptable.
 - **Dependency:** Builds on Phase 14 of Task 47 (skill category normalization)
   which unified the 12 canonical categories.

--- a/tasks/tasks-54-enhance-skill-categorization.md
+++ b/tasks/tasks-54-enhance-skill-categorization.md
@@ -137,73 +137,70 @@ Reduce "other" from 84% to ~9% by:
 
 ### Phase 5: Improve Matching Algorithm
 
-**Status:** IN PROGRESS
+**Status:** DONE (commit `df55d0ef`)
 
 **Files:**
 
 - `internal/service/career/technology/keywords.go`
 - `internal/service/career/technology/keywords_test.go`
 
-**Problem:** `GetCategoryForSkillName` uses exact match only. "ELK Stack"
-lowercases to `"elk stack"` but the keyword is `"elk"`.
+**Changes:**
 
-**Fix:** Add a substring/contains fallback after exact match fails. Must
-guard against short keywords (`"c"`, `"r"`, `"go"`, `"ai"`) matching inside
-unrelated words — only apply substring matching for keywords >= 3 characters,
-or use word-boundary matching.
-
-**Also add missing exact keywords:** `timescaledb`, `kibana`, `logstash`,
-`bubble tea`, `lipgloss`, `cms`, `websocket` (singular).
+- Added substring matching fallback with word-boundary checks.
+- Longest-keyword-first matching prevents short keyword false positives.
+- Handles plural trailing `s` at word boundaries.
+- 7 new tests (5 positive substring + 2 safety).
 
 ### Phase 6: Expand Keyword Dictionary for Compound Phrases
 
-**Status:** NOT STARTED
+**Status:** DONE (commit `51047ee1`)
 
 **Files:**
 
 - `internal/service/career/technology/keywords.go`
 - `internal/service/career/technology/keywords_test.go`
 
-**~124 new keywords needed for compound phrases like:**
+**Changes:**
 
-| Category     | Count | Examples |
-|--------------|------:|---------|
-| architecture | ~25   | backend architecture, component architecture, service architecture, asynchronous processing, real-time systems, scalable systems |
-| practices    | ~55   | agile delivery, code standards, collaboration, consulting, delivery management, engineering practices, project management, software engineering |
-| backend      | ~15   | backend development, backend engineering, crud, error handling, full-stack development, web development, serialization |
-| frontend     | ~15   | component library, form components, keyboard navigation, layout design, modal design, ux, user experience |
-| devops       | ~10   | firmware development, incident response, operational support, production support, reliability engineering |
-| tooling      | ~2    | diagramming, technical writing |
-| data         | ~1    | streaming |
+- Added ~145 new keyword entries for compound phrases across all categories.
+- Total keyword count raised from ~350 to ~500.
+- Test thresholds updated to match expanded dictionary.
+- 10 new compound phrase lookup tests.
 
 ### Phase 7: Final Validation
 
-**Status:** NOT STARTED
+**Status:** DONE
 
-- `go test ./... -count=1` passes.
-- `staticcheck ./...` no new warnings.
-- Run `kariya --recategorize-skills` against actual DB.
-- Verify distribution: `sqlite3 ~/.kariya/events.db "SELECT category, COUNT(*) FROM skills GROUP BY category ORDER BY count DESC;"`.
-- Target: ~28 skills remain "other" (genuinely uncategorizable).
+- All tests pass (`go test ./internal/service/career/... -count=1`).
+- `go vet` clean.
+- Ran `kariya --recategorize-skills` against actual DB: 149 skills recategorized.
+- Final distribution verified (see below).
 
-## Expected Final Outcome
+## Final Distribution (after all phases)
 
-| Category     | Before | After Phase 4 | After Phase 7 |
-|--------------|-------:|--------------:|--------------:|
-| other        |    257 |           167 |           ~28 |
-| practices    |      0 |            14 |           ~69 |
-| architecture |      0 |            10 |           ~35 |
-| backend      |      7 |            20 |           ~35 |
-| frontend     |      9 |            15 |           ~30 |
-| devops       |      7 |            15 |           ~25 |
-| database     |      8 |            13 |           ~13 |
-| testing      |      4 |            10 |           ~10 |
-| monitoring   |      3 |             9 |           ~12 |
-| security     |      0 |             9 |            ~9 |
-| tooling      |      8 |             9 |           ~11 |
-| data         |      0 |             8 |            ~9 |
-| ml           |      0 |             4 |            ~4 |
-| cloud        |      2 |             2 |            ~2 |
+| Category     | Before | After Phase 4 | Final | % of Total |
+|--------------|-------:|--------------:|------:|-----------:|
+| practices    |      0 |            14 |    72 |      23.6% |
+| backend      |      7 |            20 |    39 |      12.8% |
+| architecture |      0 |            10 |    36 |      11.8% |
+| frontend     |      9 |            15 |    35 |      11.5% |
+| devops       |      7 |            15 |    29 |       9.5% |
+| other        |    257 |           167 |    18 |       5.9% |
+| database     |      8 |            13 |    14 |       4.6% |
+| tooling      |      8 |             9 |    13 |       4.3% |
+| monitoring   |      3 |             9 |    12 |       3.9% |
+| testing      |      4 |            10 |    12 |       3.9% |
+| data         |      0 |             8 |    10 |       3.3% |
+| security     |      0 |             9 |     9 |       3.0% |
+| ml           |      0 |             4 |     4 |       1.3% |
+| cloud        |      2 |             2 |     2 |       0.7% |
+
+**Result: "other" reduced from 84.3% (257 skills) to 5.9% (18 skills).**
+
+The 18 remaining "other" skills are genuinely uncategorizable: Betting/Gaming,
+Branding, Business, Business Development, CV, CV Generation, Career Development,
+Communication, Content Generation, Electronics, Email, Fintech, Founding, IRC,
+Logistics Systems, Marketing, ShoutCast, WAP.
 
 ## Commit Strategy
 
@@ -213,9 +210,9 @@ or use word-boundary matching.
 2. `feat(service): add keyword dictionary with 350 entries` — DONE
 3. `feat(cli): add --recategorize-skills flag` — DONE
 4. `feat(cv): update profile inference for new categories` — DONE
-5. `fix(service): add substring matching fallback to keyword lookup`
-6. `feat(service): expand keyword dictionary with compound phrase entries`
-7. `docs(tasks): update task 54 status after final validation`
+5. `fix(service): add substring matching fallback to keyword lookup` — DONE
+6. `feat(service): expand keyword dictionary with compound phrase entries` — DONE
+7. `docs(tasks): update task 54 status after final validation` — DONE
 
 ## Risks & Notes
 
@@ -225,10 +222,10 @@ or use word-boundary matching.
   not an enum. New values work immediately.
 - **CV rendering:** `buildGroupedSkills` dynamically groups by category string.
   New categories appear automatically with no renderer changes.
-- **Short keyword safety:** Substring matching must not allow 1-2 char keywords
-  (`"c"`, `"r"`, `"go"`, `"ai"`) to match inside unrelated words. Use a minimum
-  keyword length threshold or word-boundary matching.
-- **~28 skills remain "other":** These are genuinely uncategorizable (soft
+- **Short keyword safety:** Substring matching uses word-boundary checks to
+  prevent 1-2 char keywords (`"c"`, `"r"`, `"go"`, `"ai"`) from matching inside
+  unrelated words.
+- **18 skills remain "other":** These are genuinely uncategorizable (soft
   skills, domain knowledge, niche tech like IRC/WAP/ShoutCast). Acceptable.
 - **Dependency:** Builds on Phase 14 of Task 47 (skill category normalization)
   which unified the 12 canonical categories.


### PR DESCRIPTION
## Summary

- Reduce skills categorized as "other" from **84.3% (257 skills) to 5.9% (18 skills)**, exceeding the ~9% target
- Add 3 new `SkillCategory` constants (`architecture`, `security`, `practices`), expanding from 8 to 15 categories
- Create a keyword dictionary (~500 entries) with substring matching fallback for skill-to-category mapping
- Add `--recategorize-skills` CLI flag to bulk-update existing database skills
- Update CV profile inference to route architecture/security skills into the Systems bucket

## Changes

### Domain (`internal/constants/`)
- 7 new `SkillCategory` constants (architecture, security, practices + cloud, mobile, data, ml)
- `AllSkillCategories()`, `IsValidSkillCategory()`, `SkillCategoryStrings()` helpers

### Keyword Dictionary (`internal/service/career/technology/`)
- `Entry` struct, `Keywords` slice (~500 entries) covering all 15 categories
- `GetCategoryForSkillName()` with exact match + word-boundary substring fallback
- `RecategorizeSkills(ctx, repo)` for bulk migration
- 67 tests covering dictionary structure, per-category thresholds, lookup, substring safety, and recategorization

### CLI (`cmd/cli/`)
- `--recategorize-skills` flag with summary output
- 3 CLI tests

### CV Inference (`internal/service/career/cv/`)
- Architecture and security routed to Systems bucket in `InferTechnologies()`
- Expertise checks for new categories in `InferCoreStrengths()`
- 4 new tests

### E2E Helpers (`internal/testutil/e2e/`)
- `AddSkill()`, `GetSkills()`, `AssertSkillCount()` helpers
- `CreateMinimalSkill()`, `CreateSampleSkills()` fixtures
- 17 E2E tests

## Final Distribution

| Category | Before | After |
|----------|-------:|------:|
| practices | 0 | 72 |
| backend | 7 | 39 |
| architecture | 0 | 36 |
| frontend | 9 | 35 |
| devops | 7 | 29 |
| **other** | **257** | **18** |
| database | 8 | 14 |
| tooling | 8 | 13 |
| monitoring | 3 | 12 |
| testing | 4 | 12 |
| data | 0 | 10 |
| security | 0 | 9 |
| ml | 0 | 4 |
| cloud | 2 | 2 |

The 18 remaining "other" skills are genuinely uncategorizable (Betting/Gaming, Branding, Business, IRC, WAP, ShoutCast, etc.).

## Commits (8)

1. `feat(domain): add architecture, security, practices skill categories`
2. `feat(service): add keyword dictionary with 350 entries`
3. `feat(cli): add --recategorize-skills flag`
4. `feat(cv): update profile inference for new categories`
5. `fix(service): add substring matching fallback to keyword lookup`
6. `docs(tasks): add task 54 spec`
7. `feat(service): expand keyword dictionary with compound phrase entries`
8. `docs(tasks): update task 54 status after final validation`