### PR TITLE
fix(ci): add CODECOV_TOKEN to architecture-lint workflow

### DIFF
--- a/.github/workflows/architecture-lint.yml
+++ b/.github/workflows/architecture-lint.yml
@@ -205,11 +205,13 @@ jobs:
 
       - name: Upload coverage
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.out
+          files: ./coverage.out
           flags: unittests
           name: codecov-umbrella
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   report:
     name: Architecture Report


### PR DESCRIPTION
## Summary

Codecov upload fails on protected branches (next/main) with error:
```
error - Upload failed: {"message":"Token required because branch is protected"}
```

## Changes

- Upgrade codecov-action from @v4 to @v5
- Add `token: ${{ secrets.CODECOV_TOKEN }}` parameter
- Change `file:` to `files:` (plural) for consistency with ci.yml
- Add `fail_ci_if_error: false` for consistency with ci.yml

## Root Cause

Protected branches require explicit token authentication for Codecov uploads. This matches the pattern already established in ci.yml.