### PR TITLE
fix(ci): enable auto-merge for dependabot PRs on open

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,14 +4,13 @@ on:
   pull_request:
     types: [opened, reopened, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   enable-auto-merge-dependabot:
     name: Enable Auto Merge (Dependabot)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     if: github.event.pull_request.user.login == 'dependabot[bot]' && (github.event.action == 'opened' || github.event.action == 'reopened')
     steps:
       - name: Enable auto-merge (squash)
@@ -24,6 +23,9 @@ jobs:
   enable-auto-merge-ready:
     name: Enable Auto Merge (Ready for Review)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     if: github.event.action == 'ready_for_review' && !github.event.pull_request.draft
     steps:
       - name: Enable auto-merge (squash)

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,10 +12,10 @@ jobs:
   enable-auto-merge-dependabot:
     name: Enable Auto Merge (Dependabot)
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]' && (github.event.action == 'opened' || github.event.action == 'reopened')
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && (github.event.action == 'opened' || github.event.action == 'reopened')
     steps:
       - name: Enable auto-merge (squash)
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d  # v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
@@ -27,7 +27,7 @@ jobs:
     if: github.event.action == 'ready_for_review' && !github.event.pull_request.draft
     steps:
       - name: Enable auto-merge (squash)
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d  # v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,18 +2,29 @@ name: Auto Merge
 
 on:
   pull_request:
-    types: [ready_for_review]
+    types: [opened, reopened, ready_for_review]
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
-  enable-auto-merge:
-    name: Enable Auto Merge
+  enable-auto-merge-dependabot:
+    name: Enable Auto Merge (Dependabot)
     runs-on: ubuntu-latest
-    # Only enable auto-merge for non-draft PRs
-    if: ${{ !github.event.pull_request.draft }}
+    if: github.actor == 'dependabot[bot]' && (github.event.action == 'opened' || github.event.action == 'reopened')
+    steps:
+      - name: Enable auto-merge (squash)
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash
+
+  enable-auto-merge-ready:
+    name: Enable Auto Merge (Ready for Review)
+    runs-on: ubuntu-latest
+    if: github.event.action == 'ready_for_review' && !github.event.pull_request.draft
     steps:
       - name: Enable auto-merge (squash)
         uses: peter-evans/enable-pull-request-automerge@v3


### PR DESCRIPTION
## Summary

- Adds `opened` and `reopened` triggers to auto-merge workflow
- Splits into two jobs: one for dependabot PRs (on open), one for draft→ready transitions
- Fixes: dependabot PRs were not auto-merging because they're created as non-draft

## Problem

Dependabot PRs are created as ready (non-draft), so the `ready_for_review` event never fires. Result: 7 open dependabot PRs have `autoMergeRequest: null`.

## Solution

| Job | Trigger | Condition |
|-----|---------|-----------|
| `enable-auto-merge-dependabot` | `opened`, `reopened` | `github.actor == 'dependabot[bot]'` |
| `enable-auto-merge-ready` | `ready_for_review` | `!github.event.pull_request.draft` |

## Security

- Only dependabot PRs enable auto-merge on open (not all PRs)
- `github.actor` is safe to check in `pull_request` events (not forgeable like in `workflow_run`)

## Related

- PR #190 (merged): Created dependabot-auto-rebase workflow
- PR #191 (merged): Fixed codecov token in architecture-lint