### PR TITLE
fix(ci): add CODECOV_TOKEN to architecture-lint test job

### DIFF
--- a/.github/workflows/architecture-lint.yml
+++ b/.github/workflows/architecture-lint.yml
@@ -203,13 +203,15 @@ jobs:
       - name: Run tests
         run: ginkgo -v --race --cover --coverprofile="coverage.out" --skip-package=testdata,noinlinecareer/testdata,features ./...
 
-      - name: Upload coverage
+      - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.out
+          files: ./coverage.out
           flags: unittests
           name: codecov-umbrella
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   report:
     name: Architecture Report


### PR DESCRIPTION
## Summary

- Fix codecov coverage upload for `next` branch in `architecture-lint.yml`
- PR #191 fixed `ci.yml` but missed the test job in `architecture-lint.yml`
- Protected branches require explicit token authentication for codecov uploads

## Changes

| Change | Before | After |
|--------|--------|-------|
| Action version | `@v4` | `@v5` |
| Step name | "Upload coverage" | "Upload coverage to Codecov" |
| File parameter | `file:` | `files:` |
| Token | ❌ missing | ✅ `${{ secrets.CODECOV_TOKEN }}` |
| Error handling | ❌ missing | ✅ `fail_ci_if_error: false` |

## Root Cause

The `architecture-lint.yml` workflow runs tests on push to `next/main` branches and uploads coverage. Without the token, protected branches fail with:
```
error - Upload failed: {"message":"Token required because branch is protected"}
```

## Testing

- YAML syntax validated
- Pattern matches working configuration in `ci.yml` lines 179-187