### PR TITLE
fix(ci): add push trigger to run tests on merge to next/main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,11 @@
 name: CI
 
 on:
-  # Only run on PRs to avoid duplicate test runs
-  # Push to next/main is covered by architecture-lint.yml
   pull_request:
+    branches:
+      - next
+      - main
+  push:
     branches:
       - next
       - main


### PR DESCRIPTION
## Summary

- Adds `push` trigger to `ci.yml` for `next` and `main` branches
- Ensures tests run when PRs are merged, not just on PR events
- Enables Codecov to receive baseline coverage data from `next` branch

## Problem

The CI workflow only triggered on `pull_request` events. When code was merged to `next`:
1. No tests ran on the merged commit
2. Codecov had no baseline coverage for `next` branch
3. Post-merge breakage could go undetected

## Solution

Added `push` trigger alongside existing `pull_request` trigger:

```yaml
on:
  pull_request:
    branches:
      - next
      - main
  push:
    branches:
      - next
      - main
```

## Changes

- `.github/workflows/ci.yml`: Added `push` trigger, removed misleading comment

## Testing

- YAML syntax is valid
- No functional changes to test jobs - just trigger conditions