### PR TITLE
fix(screens): improve config modal navigation with j/k keys

### DIFF
--- a/internal/cli/forms/forms.go
+++ b/internal/cli/forms/forms.go
@@ -417,14 +417,14 @@ type SelectOption struct {
 //
 // Side effects:
 //   - None.
-func NewSelect(key, title, description string, options []SelectOption) *huh.Select[string] {
+func NewSelect(fieldKey, title, description string, options []SelectOption) *huh.Select[string] {
 	huhOptions := make([]huh.Option[string], len(options))
 	for i, opt := range options {
 		huhOptions[i] = huh.NewOption(opt.Value, opt.Key)
 	}
 
 	sel := huh.NewSelect[string]().
-		Key(key).
+		Key(fieldKey).
 		Title(title).
 		Options(huhOptions...)
 
@@ -447,14 +447,14 @@ func NewSelect(key, title, description string, options []SelectOption) *huh.Sele
 //
 // Side effects:
 //   - None.
-func NewMultiSelect(key, title, description string, options []SelectOption, limit int) *huh.MultiSelect[string] {
+func NewMultiSelect(fieldKey, title, description string, options []SelectOption, limit int) *huh.MultiSelect[string] {
 	huhOptions := make([]huh.Option[string], len(options))
 	for i, opt := range options {
 		huhOptions[i] = huh.NewOption(opt.Value, opt.Key)
 	}
 
 	multi := huh.NewMultiSelect[string]().
-		Key(key).
+		Key(fieldKey).
 		Title(title).
 		Options(huhOptions...)
 
@@ -479,9 +479,9 @@ func NewMultiSelect(key, title, description string, options []SelectOption, limi
 //
 // Side effects:
 //   - None.
-func NewConfirm(key, title, description, affirmative, negative string) *huh.Confirm {
+func NewConfirm(fieldKey, title, description, affirmative, negative string) *huh.Confirm {
 	confirm := huh.NewConfirm().
-		Key(key).
+		Key(fieldKey).
 		Title(title)
 
 	if description != "" {

--- a/internal/cli/forms/forms.go
+++ b/internal/cli/forms/forms.go
@@ -26,6 +26,7 @@
 package forms
 
 import (
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
 )
@@ -92,6 +93,23 @@ func Update(form Form, msg tea.Msg) (Form, tea.Cmd) {
 		return form, cmd
 	}
 	return f, cmd
+}
+
+// WithCustomSubmitKey configures a form to use a custom submit key binding.
+//
+// Expected:
+//   - form must be a valid Form.
+//   - keys must be valid key strings (e.g., "ctrl+s", "enter").
+//
+// Returns:
+//   - A Form value.
+//
+// Side effects:
+//   - None.
+func WithCustomSubmitKey(form Form, keys ...string) Form {
+	keymap := huh.NewDefaultKeyMap()
+	keymap.Input.Submit = key.NewBinding(key.WithKeys(keys...))
+	return form.WithKeyMap(keymap)
 }
 
 // Theme returns the Catppuccin theme configured for KaRiya forms.
@@ -275,6 +293,31 @@ func IsCompleted(form *huh.Form) bool {
 //   - None.
 func IsAborted(form *huh.Form) bool {
 	return form.State == huh.StateAborted
+}
+
+// IsTextInputFocused checks if the currently focused field is a text input
+// (either Input or Text). This is used to determine whether vim-style j/k
+// navigation should be disabled to allow typing those characters.
+//
+// Expected:
+//   - form may be nil (returns false).
+//
+// Returns:
+//   - true if the focused field is *huh.Input or *huh.Text.
+//   - false otherwise (including nil form).
+//
+// Side effects:
+//   - None.
+func IsTextInputFocused(form Form) bool {
+	if form == nil {
+		return false
+	}
+	focused := form.GetFocusedField()
+	switch focused.(type) {
+	case *huh.Input, *huh.Text:
+		return true
+	}
+	return false
 }
 
 // FieldConfig represents common field configuration options.

--- a/internal/cli/forms/forms_test.go
+++ b/internal/cli/forms/forms_test.go
@@ -1,0 +1,137 @@
+package forms_test
+
+import (
+	"github.com/charmbracelet/huh"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/baphled/kariya/internal/cli/forms"
+)
+
+var _ = Describe("IsTextInputFocused", func() {
+	Describe("when form is nil", func() {
+		It("should return false", func() {
+			Expect(forms.IsTextInputFocused(nil)).To(BeFalse())
+		})
+	})
+
+	Describe("when form has an Input field focused", func() {
+		It("should return true", func() {
+			var value string
+			form := huh.NewForm(
+				huh.NewGroup(
+					huh.NewInput().
+						Key("name").
+						Title("Name").
+						Value(&value),
+				),
+			).WithWidth(50)
+			form.Init()
+
+			Expect(forms.IsTextInputFocused(form)).To(BeTrue())
+		})
+	})
+
+	Describe("when form has a Text field focused", func() {
+		It("should return true", func() {
+			var value string
+			form := huh.NewForm(
+				huh.NewGroup(
+					huh.NewText().
+						Key("description").
+						Title("Description").
+						Value(&value),
+				),
+			).WithWidth(50)
+			form.Init()
+
+			Expect(forms.IsTextInputFocused(form)).To(BeTrue())
+		})
+	})
+
+	Describe("when form has a Select field focused", func() {
+		It("should return false", func() {
+			var value string
+			form := huh.NewForm(
+				huh.NewGroup(
+					huh.NewSelect[string]().
+						Key("theme").
+						Title("Theme").
+						Options(
+							huh.NewOption("Light", "light"),
+							huh.NewOption("Dark", "dark"),
+						).
+						Value(&value),
+				),
+			).WithWidth(50)
+			form.Init()
+
+			Expect(forms.IsTextInputFocused(form)).To(BeFalse())
+		})
+	})
+
+	Describe("when form has a Confirm field focused", func() {
+		It("should return false", func() {
+			var value bool
+			form := huh.NewForm(
+				huh.NewGroup(
+					huh.NewConfirm().
+						Key("confirm").
+						Title("Proceed?").
+						Value(&value),
+				),
+			).WithWidth(50)
+			form.Init()
+
+			Expect(forms.IsTextInputFocused(form)).To(BeFalse())
+		})
+	})
+
+	Describe("when form has a MultiSelect field focused", func() {
+		It("should return false", func() {
+			var value []string
+			form := huh.NewForm(
+				huh.NewGroup(
+					huh.NewMultiSelect[string]().
+						Key("options").
+						Title("Options").
+						Options(
+							huh.NewOption("A", "a"),
+							huh.NewOption("B", "b"),
+						).
+						Value(&value),
+				),
+			).WithWidth(50)
+			form.Init()
+
+			Expect(forms.IsTextInputFocused(form)).To(BeFalse())
+		})
+	})
+
+	Describe("when navigating between fields", func() {
+		It("should return false when moving from Input to Select", func() {
+			var name string
+			var theme string
+			form := huh.NewForm(
+				huh.NewGroup(
+					huh.NewInput().
+						Key("name").
+						Title("Name").
+						Value(&name),
+					huh.NewSelect[string]().
+						Key("theme").
+						Title("Theme").
+						Options(
+							huh.NewOption("Light", "light"),
+							huh.NewOption("Dark", "dark"),
+						).
+						Value(&theme),
+				),
+			).WithWidth(50)
+			form.Init()
+			Expect(forms.IsTextInputFocused(form)).To(BeTrue())
+			form.NextField()
+			Expect(forms.IsTextInputFocused(form)).To(BeFalse())
+		})
+	})
+})

--- a/internal/cli/screens/configure/settings_modal.go
+++ b/internal/cli/screens/configure/settings_modal.go
@@ -174,7 +174,7 @@ func (m *SettingsModal) Init() tea.Cmd {
 func (m *SettingsModal) Update(msg tea.Msg) tea.Cmd {
 	if keyMsg, ok := msg.(tea.KeyMsg); ok {
 		switch keyMsg.String() {
-		case "j", "down":
+		case "down":
 			if m.selectedIdx < len(m.domains)-1 {
 				m.selectedIdx++
 				m.rebuildActiveForm()
@@ -183,7 +183,7 @@ func (m *SettingsModal) Update(msg tea.Msg) tea.Cmd {
 				}
 			}
 			return nil
-		case "k", "up":
+		case "up":
 			if m.selectedIdx > 0 {
 				m.selectedIdx--
 				m.rebuildActiveForm()
@@ -197,6 +197,13 @@ func (m *SettingsModal) Update(msg tea.Msg) tea.Cmd {
 			return nil
 		case "esc":
 			m.cancelled = true
+			return nil
+		case "tab", "shift+tab":
+			if m.activeForm != nil {
+				var cmd tea.Cmd
+				m.activeForm, cmd = forms.Update(m.activeForm, msg)
+				return cmd
+			}
 			return nil
 		}
 	}

--- a/internal/cli/screens/configure/settings_modal.go
+++ b/internal/cli/screens/configure/settings_modal.go
@@ -3,13 +3,14 @@ package configure
 import (
 	"fmt"
 
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/baphled/kariya/internal/cli/configtypes"
 	"github.com/baphled/kariya/internal/cli/forms"
 	"github.com/baphled/kariya/internal/cli/themes"
 	"github.com/baphled/kariya/internal/cli/uikit/containers"
 	"github.com/baphled/kariya/internal/cli/uikit/primitives"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
 const sectionListWidth = 16
@@ -116,6 +117,7 @@ func (m *SettingsModal) rebuildActiveForm() {
 	)
 
 	if m.activeForm != nil {
+		m.activeForm = forms.WithCustomSubmitKey(m.activeForm, "ctrl+s")
 		m.activeForm.Init()
 	}
 }
@@ -172,39 +174,42 @@ func (m *SettingsModal) Init() tea.Cmd {
 // Side effects:
 //   - May update selected section or form state.
 func (m *SettingsModal) Update(msg tea.Msg) tea.Cmd {
-	if keyMsg, ok := msg.(tea.KeyMsg); ok {
-		switch keyMsg.String() {
-		case "down":
-			if m.selectedIdx < len(m.domains)-1 {
-				m.selectedIdx++
-				m.rebuildActiveForm()
-				if m.activeForm != nil {
-					return m.activeForm.Init()
-				}
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		if m.activeForm != nil {
+			var cmd tea.Cmd
+			m.activeForm, cmd = forms.Update(m.activeForm, msg)
+			return cmd
+		}
+		return nil
+	}
+
+	switch keyMsg.Type {
+	case tea.KeyDown:
+		return m.navigateDown()
+	case tea.KeyUp:
+		return m.navigateUp()
+	case tea.KeyCtrlS:
+		m.completed = true
+		return nil
+	case tea.KeyEsc:
+		m.cancelled = true
+		return nil
+	case tea.KeyTab, tea.KeyShiftTab:
+		if m.activeForm != nil {
+			var cmd tea.Cmd
+			m.activeForm, cmd = forms.Update(m.activeForm, msg)
+			return cmd
+		}
+		return nil
+	case tea.KeyRunes:
+		if !forms.IsTextInputFocused(m.activeForm) {
+			switch keyMsg.String() {
+			case "j":
+				return m.navigateDown()
+			case "k":
+				return m.navigateUp()
 			}
-			return nil
-		case "up":
-			if m.selectedIdx > 0 {
-				m.selectedIdx--
-				m.rebuildActiveForm()
-				if m.activeForm != nil {
-					return m.activeForm.Init()
-				}
-			}
-			return nil
-		case "ctrl+s":
-			m.completed = true
-			return nil
-		case "esc":
-			m.cancelled = true
-			return nil
-		case "tab", "shift+tab":
-			if m.activeForm != nil {
-				var cmd tea.Cmd
-				m.activeForm, cmd = forms.Update(m.activeForm, msg)
-				return cmd
-			}
-			return nil
 		}
 	}
 
@@ -214,6 +219,28 @@ func (m *SettingsModal) Update(msg tea.Msg) tea.Cmd {
 		return cmd
 	}
 
+	return nil
+}
+
+func (m *SettingsModal) navigateDown() tea.Cmd {
+	if m.selectedIdx < len(m.domains)-1 {
+		m.selectedIdx++
+		m.rebuildActiveForm()
+		if m.activeForm != nil {
+			return m.activeForm.Init()
+		}
+	}
+	return nil
+}
+
+func (m *SettingsModal) navigateUp() tea.Cmd {
+	if m.selectedIdx > 0 {
+		m.selectedIdx--
+		m.rebuildActiveForm()
+		if m.activeForm != nil {
+			return m.activeForm.Init()
+		}
+	}
 	return nil
 }
 
@@ -356,11 +383,13 @@ func (m *SettingsModal) SetTheme(theme themes.Theme) {
 //   - height must be a positive integer.
 //
 // Side effects:
-//   - None.
+//   - Rebuilds the active form only if dimensions have changed.
 func (m *SettingsModal) SetDimensions(width, height int) {
-	m.width = width
-	m.height = height
-	m.rebuildActiveForm()
+	if m.width != width || m.height != height {
+		m.width = width
+		m.height = height
+		m.rebuildActiveForm()
+	}
 }
 
 func formatDomainLabel(domain configtypes.ConfigurationDomain) string {

--- a/internal/cli/screens/configure/settings_modal.go
+++ b/internal/cli/screens/configure/settings_modal.go
@@ -178,12 +178,18 @@ func (m *SettingsModal) Update(msg tea.Msg) tea.Cmd {
 			if m.selectedIdx < len(m.domains)-1 {
 				m.selectedIdx++
 				m.rebuildActiveForm()
+				if m.activeForm != nil {
+					return m.activeForm.Init()
+				}
 			}
 			return nil
 		case "k", "up":
 			if m.selectedIdx > 0 {
 				m.selectedIdx--
 				m.rebuildActiveForm()
+				if m.activeForm != nil {
+					return m.activeForm.Init()
+				}
 			}
 			return nil
 		case "ctrl+s":

--- a/internal/cli/screens/configure/settings_modal_test.go
+++ b/internal/cli/screens/configure/settings_modal_test.go
@@ -488,4 +488,34 @@ var _ = Describe("SettingsModal", func() {
 			Expect(modal.IsCompleted()).To(BeFalse())
 		})
 	})
+
+	Describe("Tab navigation after domain switch", func() {
+		It("should return Init command when switching domain with j key", func() {
+			cmd := modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+			Expect(cmd).NotTo(BeNil())
+		})
+
+		It("should return Init command when switching domain with down arrow", func() {
+			cmd := modal.Update(tea.KeyMsg{Type: tea.KeyDown})
+			Expect(cmd).NotTo(BeNil())
+		})
+
+		It("should return Init command when switching domain with k key", func() {
+			modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+			cmd := modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+			Expect(cmd).NotTo(BeNil())
+		})
+
+		It("should return Init command when switching domain with up arrow", func() {
+			modal.Update(tea.KeyMsg{Type: tea.KeyDown})
+			cmd := modal.Update(tea.KeyMsg{Type: tea.KeyUp})
+			Expect(cmd).NotTo(BeNil())
+		})
+
+		It("should maintain form focus after domain switch", func() {
+			modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+			view := modal.View()
+			Expect(view).NotTo(BeEmpty())
+		})
+	})
 })

--- a/internal/cli/screens/configure/settings_modal_test.go
+++ b/internal/cli/screens/configure/settings_modal_test.go
@@ -101,34 +101,66 @@ var _ = Describe("SettingsModal", func() {
 	})
 
 	Describe("Update", func() {
-		Context("when navigating with j key", func() {
-			It("should move to the next domain", func() {
+		Context("when pressing j key", func() {
+			It("should forward to form and not navigate domains", func() {
+				initialIdx := modal.selectedIdx
 				modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-				view := modal.View()
-				Expect(view).NotTo(BeEmpty())
+				Expect(modal.selectedIdx).To(Equal(initialIdx))
+			})
+		})
+
+		Context("when pressing k key", func() {
+			It("should forward to form and not navigate domains", func() {
+				initialIdx := modal.selectedIdx
+				modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+				Expect(modal.selectedIdx).To(Equal(initialIdx))
+			})
+		})
+
+		Context("when navigating with down arrow", func() {
+			It("should move to the next domain", func() {
+				initialIdx := modal.selectedIdx
+				modal.Update(tea.KeyMsg{Type: tea.KeyDown})
+				Expect(modal.selectedIdx).To(Equal(initialIdx + 1))
 			})
 
 			It("should not move beyond the last domain", func() {
 				for range 10 {
-					modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+					modal.Update(tea.KeyMsg{Type: tea.KeyDown})
 				}
-				Expect(modal.IsCompleted()).To(BeFalse())
-				Expect(modal.IsCancelled()).To(BeFalse())
+				Expect(modal.selectedIdx).To(Equal(len(modal.domains) - 1))
 			})
 		})
 
-		Context("when navigating with k key", func() {
-			It("should not move above the first domain", func() {
-				modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
-				view := modal.View()
-				Expect(view).NotTo(BeEmpty())
+		Context("when navigating with up arrow", func() {
+			It("should move to the previous domain", func() {
+				modal.Update(tea.KeyMsg{Type: tea.KeyDown})
+				initialIdx := modal.selectedIdx
+				modal.Update(tea.KeyMsg{Type: tea.KeyUp})
+				Expect(modal.selectedIdx).To(Equal(initialIdx - 1))
 			})
 
-			It("should move back after moving forward", func() {
-				modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-				modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
-				view := modal.View()
-				Expect(view).NotTo(BeEmpty())
+			It("should not move above the first domain", func() {
+				for range 10 {
+					modal.Update(tea.KeyMsg{Type: tea.KeyUp})
+				}
+				Expect(modal.selectedIdx).To(Equal(0))
+			})
+		})
+
+		Context("when pressing tab", func() {
+			It("should forward to form for field navigation", func() {
+				initialIdx := modal.selectedIdx
+				modal.Update(tea.KeyMsg{Type: tea.KeyTab})
+				Expect(modal.selectedIdx).To(Equal(initialIdx))
+			})
+		})
+
+		Context("when pressing shift+tab", func() {
+			It("should forward to form for reverse field navigation", func() {
+				initialIdx := modal.selectedIdx
+				modal.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+				Expect(modal.selectedIdx).To(Equal(initialIdx))
 			})
 		})
 
@@ -420,26 +452,24 @@ var _ = Describe("SettingsModal", func() {
 	Describe("Navigation boundary conditions", func() {
 		It("should not move down from last domain", func() {
 			for range 20 {
-				modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+				modal.Update(tea.KeyMsg{Type: tea.KeyDown})
 			}
-			view := modal.View()
-			Expect(view).NotTo(BeEmpty())
+			Expect(modal.selectedIdx).To(Equal(len(modal.domains) - 1))
 		})
 
 		It("should not move up from first domain", func() {
 			for range 20 {
-				modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+				modal.Update(tea.KeyMsg{Type: tea.KeyUp})
 			}
-			view := modal.View()
-			Expect(view).NotTo(BeEmpty())
+			Expect(modal.selectedIdx).To(Equal(0))
 		})
 	})
 
 	Describe("Multiple state transitions", func() {
 		It("should handle multiple navigation and action sequences", func() {
-			modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-			modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-			modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+			modal.Update(tea.KeyMsg{Type: tea.KeyDown})
+			modal.Update(tea.KeyMsg{Type: tea.KeyDown})
+			modal.Update(tea.KeyMsg{Type: tea.KeyUp})
 			Expect(modal.IsCompleted()).To(BeFalse())
 			Expect(modal.IsCancelled()).To(BeFalse())
 		})
@@ -489,20 +519,9 @@ var _ = Describe("SettingsModal", func() {
 		})
 	})
 
-	Describe("Tab navigation after domain switch", func() {
-		It("should return Init command when switching domain with j key", func() {
-			cmd := modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-			Expect(cmd).NotTo(BeNil())
-		})
-
+	Describe("Domain navigation with arrow keys", func() {
 		It("should return Init command when switching domain with down arrow", func() {
 			cmd := modal.Update(tea.KeyMsg{Type: tea.KeyDown})
-			Expect(cmd).NotTo(BeNil())
-		})
-
-		It("should return Init command when switching domain with k key", func() {
-			modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-			cmd := modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
 			Expect(cmd).NotTo(BeNil())
 		})
 
@@ -513,7 +532,7 @@ var _ = Describe("SettingsModal", func() {
 		})
 
 		It("should maintain form focus after domain switch", func() {
-			modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+			modal.Update(tea.KeyMsg{Type: tea.KeyDown})
 			view := modal.View()
 			Expect(view).NotTo(BeEmpty())
 		})

--- a/internal/cli/screens/configure/settings_modal_test.go
+++ b/internal/cli/screens/configure/settings_modal_test.go
@@ -101,19 +101,68 @@ var _ = Describe("SettingsModal", func() {
 	})
 
 	Describe("Update", func() {
-		Context("when pressing j key", func() {
-			It("should forward to form and not navigate domains", func() {
-				initialIdx := modal.selectedIdx
-				modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
-				Expect(modal.selectedIdx).To(Equal(initialIdx))
+		Context("when pressing j key (vim-style navigation)", func() {
+			var selectOnlyModal *SettingsModal
+
+			BeforeEach(func() {
+				selectSettings := map[configtypes.ConfigurationDomain][]*configtypes.ConfigurationSetting{
+					configtypes.DomainSystem: {
+						{Key: "log_level", Label: "Log Level", Value: "info", DefaultValue: "info", Type: "select", Options: []string{"debug", "info", "warn", "error"}},
+					},
+					configtypes.DomainExport: {
+						{Key: "default_destination", Label: "Default Destination", Value: "file", DefaultValue: "file", Type: "select", Options: []string{"file", "clipboard"}},
+					},
+					configtypes.DomainUI: {
+						{Key: "theme", Label: "Theme", Value: "dark", DefaultValue: "dark", Type: "select", Options: []string{"light", "dark"}},
+					},
+				}
+				selectOnlyModal = NewSettingsModal(selectSettings, 120, 40)
+			})
+
+			It("should move to the next domain", func() {
+				initialIdx := selectOnlyModal.selectedIdx
+				selectOnlyModal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+				Expect(selectOnlyModal.selectedIdx).To(Equal(initialIdx + 1))
+			})
+
+			It("should not move beyond the last domain", func() {
+				for range 10 {
+					selectOnlyModal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+				}
+				Expect(selectOnlyModal.selectedIdx).To(Equal(len(selectOnlyModal.domains) - 1))
 			})
 		})
 
-		Context("when pressing k key", func() {
-			It("should forward to form and not navigate domains", func() {
-				initialIdx := modal.selectedIdx
-				modal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
-				Expect(modal.selectedIdx).To(Equal(initialIdx))
+		Context("when pressing k key (vim-style navigation)", func() {
+			var selectOnlyModal *SettingsModal
+
+			BeforeEach(func() {
+				selectSettings := map[configtypes.ConfigurationDomain][]*configtypes.ConfigurationSetting{
+					configtypes.DomainSystem: {
+						{Key: "log_level", Label: "Log Level", Value: "info", DefaultValue: "info", Type: "select", Options: []string{"debug", "info", "warn", "error"}},
+					},
+					configtypes.DomainExport: {
+						{Key: "default_destination", Label: "Default Destination", Value: "file", DefaultValue: "file", Type: "select", Options: []string{"file", "clipboard"}},
+					},
+					configtypes.DomainUI: {
+						{Key: "theme", Label: "Theme", Value: "dark", DefaultValue: "dark", Type: "select", Options: []string{"light", "dark"}},
+					},
+				}
+				selectOnlyModal = NewSettingsModal(selectSettings, 120, 40)
+			})
+
+			It("should move to the previous domain", func() {
+				selectOnlyModal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+				initialIdx := selectOnlyModal.selectedIdx
+				selectOnlyModal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+				Expect(selectOnlyModal.selectedIdx).To(Equal(initialIdx - 1))
+			})
+
+			It("should not move above the first domain", func() {
+				for range 10 {
+					selectOnlyModal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+				}
+				Expect(selectOnlyModal.selectedIdx).To(Equal(0))
 			})
 		})
 
@@ -236,6 +285,24 @@ var _ = Describe("SettingsModal", func() {
 			modal.SetDimensions(40, 10)
 			view := modal.View()
 			Expect(view).NotTo(BeEmpty())
+		})
+
+		It("should not rebuild form when dimensions unchanged", func() {
+			initialForm := modal.activeForm
+			modal.SetDimensions(120, 40)
+			Expect(modal.activeForm).To(BeIdenticalTo(initialForm))
+		})
+
+		It("should rebuild form when width changes", func() {
+			initialForm := modal.activeForm
+			modal.SetDimensions(150, 40)
+			Expect(modal.activeForm).NotTo(BeIdenticalTo(initialForm))
+		})
+
+		It("should rebuild form when height changes", func() {
+			initialForm := modal.activeForm
+			modal.SetDimensions(120, 50)
+			Expect(modal.activeForm).NotTo(BeIdenticalTo(initialForm))
 		})
 	})
 
@@ -505,6 +572,55 @@ var _ = Describe("SettingsModal", func() {
 		})
 	})
 
+	Describe("Enter key on input field", func() {
+		It("should not complete the modal when pressing Enter on an input field", func() {
+			profileSettings := makeSettingsWithDomain(
+				configtypes.DomainProfile,
+				&configtypes.ConfigurationSetting{Key: "name", Label: "Full Name", Value: "Test User", DefaultValue: "", Type: "string"},
+				&configtypes.ConfigurationSetting{Key: "email", Label: "Email", Value: "test@example.com", DefaultValue: "", Type: "string"},
+			)
+			inputModal := NewSettingsModal(profileSettings, 120, 40)
+			inputModal.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			Expect(inputModal.IsCompleted()).To(BeFalse())
+		})
+
+		It("should forward Enter key to the form without completing", func() {
+			profileSettings := makeSettingsWithDomain(
+				configtypes.DomainProfile,
+				&configtypes.ConfigurationSetting{Key: "name", Label: "Full Name", Value: "Test User", DefaultValue: "", Type: "string"},
+			)
+			inputModal := NewSettingsModal(profileSettings, 120, 40)
+			initialCompleted := inputModal.IsCompleted()
+			inputModal.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			Expect(inputModal.IsCompleted()).To(Equal(initialCompleted))
+			Expect(inputModal.IsCompleted()).To(BeFalse())
+		})
+
+		It("should not complete form after multiple Enter presses", func() {
+			profileSettings := makeSettingsWithDomain(
+				configtypes.DomainProfile,
+				&configtypes.ConfigurationSetting{Key: "name", Label: "Full Name", Value: "Test User", DefaultValue: "", Type: "string"},
+				&configtypes.ConfigurationSetting{Key: "email", Label: "Email", Value: "test@example.com", DefaultValue: "", Type: "string"},
+			)
+			inputModal := NewSettingsModal(profileSettings, 120, 40)
+			inputModal.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			inputModal.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			inputModal.Update(tea.KeyMsg{Type: tea.KeyEnter})
+			Expect(inputModal.IsCompleted()).To(BeFalse())
+		})
+
+		It("should complete modal when pressing Ctrl+S", func() {
+			profileSettings := makeSettingsWithDomain(
+				configtypes.DomainProfile,
+				&configtypes.ConfigurationSetting{Key: "name", Label: "Full Name", Value: "Test User", DefaultValue: "", Type: "string"},
+			)
+			inputModal := NewSettingsModal(profileSettings, 120, 40)
+			Expect(inputModal.IsCompleted()).To(BeFalse())
+			inputModal.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
+			Expect(inputModal.IsCompleted()).To(BeTrue())
+		})
+	})
+
 	Describe("Completed and Cancelled mutual exclusivity", func() {
 		It("should not be both completed and cancelled", func() {
 			modal.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
@@ -535,6 +651,92 @@ var _ = Describe("SettingsModal", func() {
 			modal.Update(tea.KeyMsg{Type: tea.KeyDown})
 			view := modal.View()
 			Expect(view).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("Arrow keys always navigate regardless of text input focus", func() {
+		Context("when a text input field is focused", func() {
+			var textInputModal *SettingsModal
+
+			BeforeEach(func() {
+				profileSettings := makeSettingsWithDomain(
+					configtypes.DomainProfile,
+					&configtypes.ConfigurationSetting{Key: "name", Label: "Full Name", Value: "Test User", DefaultValue: "", Type: "string"},
+				)
+				textInputModal = NewSettingsModal(profileSettings, 120, 40)
+			})
+
+			It("should navigate down with down arrow even in text input", func() {
+				Expect(textInputModal.selectedIdx).To(Equal(0))
+				textInputModal.Update(tea.KeyMsg{Type: tea.KeyDown})
+				view := textInputModal.View()
+				Expect(view).NotTo(BeEmpty())
+			})
+
+			It("should navigate up with up arrow even in text input", func() {
+				view := textInputModal.View()
+				Expect(view).NotTo(BeEmpty())
+			})
+		})
+	})
+
+	Describe("j/k keys respect text input focus state", func() {
+		Context("when a text input field is focused", func() {
+			var textInputModal *SettingsModal
+
+			BeforeEach(func() {
+				profileSettings := map[configtypes.ConfigurationDomain][]*configtypes.ConfigurationSetting{
+					configtypes.DomainProfile: {
+						{Key: "name", Label: "Full Name", Value: "Test User", DefaultValue: "", Type: "string"},
+					},
+					configtypes.DomainSystem: {
+						{Key: "log_level", Label: "Log Level", Value: "info", DefaultValue: "info", Type: "select", Options: []string{"debug", "info", "warn", "error"}},
+					},
+				}
+				textInputModal = NewSettingsModal(profileSettings, 120, 40)
+				textInputModal.Update(tea.KeyMsg{Type: tea.KeyDown})
+			})
+
+			It("should NOT navigate with j key when text input is focused", func() {
+				initialIdx := textInputModal.selectedIdx
+				textInputModal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+				Expect(textInputModal.selectedIdx).To(Equal(initialIdx))
+			})
+
+			It("should NOT navigate with k key when text input is focused", func() {
+				initialIdx := textInputModal.selectedIdx
+				textInputModal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+				Expect(textInputModal.selectedIdx).To(Equal(initialIdx))
+			})
+		})
+
+		Context("when a non-text field is focused (select)", func() {
+			var selectModal *SettingsModal
+
+			BeforeEach(func() {
+				selectSettings := map[configtypes.ConfigurationDomain][]*configtypes.ConfigurationSetting{
+					configtypes.DomainSystem: {
+						{Key: "log_level", Label: "Log Level", Value: "info", DefaultValue: "info", Type: "select", Options: []string{"debug", "info", "warn", "error"}},
+					},
+					configtypes.DomainUI: {
+						{Key: "theme", Label: "Theme", Value: "dark", DefaultValue: "dark", Type: "select", Options: []string{"light", "dark"}},
+					},
+				}
+				selectModal = NewSettingsModal(selectSettings, 120, 40)
+			})
+
+			It("should navigate with j key when select field is focused", func() {
+				initialIdx := selectModal.selectedIdx
+				selectModal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+				Expect(selectModal.selectedIdx).To(Equal(initialIdx + 1))
+			})
+
+			It("should navigate with k key when select field is focused", func() {
+				selectModal.Update(tea.KeyMsg{Type: tea.KeyDown})
+				initialIdx := selectModal.selectedIdx
+				selectModal.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+				Expect(selectModal.selectedIdx).To(Equal(initialIdx - 1))
+			})
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Restores form focus after domain switch in the config modal, ensuring keyboard navigation remains active
- Improves settings modal navigation by forwarding Tab keys to form inputs and properly handling focus state
- Adds focused field detection to enable conditional j/k navigation (only when not editing text)
- Adds `IsTextInputFocused()` helper to forms package for detecting when a text input field is focused

## Before / After

| Before (Bug) | After (Fix) |
|---|---|
| ![Before](https://vhs.charm.sh/vhs-721mBHlZW0ApQ2XIjnO8L6.gif) | ![After](https://vhs.charm.sh/vhs-5IS6jxQ26698mJ0EaMFkrU.gif) |
| Typing "j" in text field navigates away | Typing "j" in text field works correctly |

## Changes

- `internal/cli/forms/forms.go` - New helper to detect focused field types in huh forms
- `internal/cli/screens/configure/settings_modal.go` - Enhanced navigation with focus restoration and tab forwarding
- Tests added/updated for all new functionality