### PR TITLE
fix(lint): resolve all golangci-lint errors on next branch

### DIFF
--- a/internal/cli/cmd/bursts/formatters.go
+++ b/internal/cli/cmd/bursts/formatters.go
@@ -28,19 +28,19 @@ func FormatBurstDetectionResults(suggestions []burst_fact.BurstSuggestion, event
 	th := theme.Default()
 	b.WriteString(primitives.Title("Burst Detection Results", th).Render())
 	b.WriteString("\n")
-	b.WriteString(fmt.Sprintf("Detected %d bursts from %d events:\n\n", len(suggestions), eventCount))
+	fmt.Fprintf(&b, "Detected %d bursts from %d events:\n\n", len(suggestions), eventCount)
 
 	for i, burst := range suggestions {
 		burstName := burst.Name
 		if burstName == "" {
 			burstName = fmt.Sprintf("Burst %d", i+1)
 		}
-		b.WriteString(fmt.Sprintf("%d. %s\n", i+1, burstName))
-		b.WriteString(fmt.Sprintf("   Events: %d\n", len(burst.EventIDs)))
+		fmt.Fprintf(&b, "%d. %s\n", i+1, burstName)
+		fmt.Fprintf(&b, "   Events: %d\n", len(burst.EventIDs))
 		if burst.Description != "" {
-			b.WriteString(fmt.Sprintf("   Description: %s\n", burst.Description))
+			fmt.Fprintf(&b, "   Description: %s\n", burst.Description)
 		}
-		b.WriteString(fmt.Sprintf("   Confidence: %.1f%%\n", burst.ConfidenceScore*100))
+		fmt.Fprintf(&b, "   Confidence: %.1f%%\n", burst.ConfidenceScore*100)
 		b.WriteString("\n")
 	}
 
@@ -84,23 +84,23 @@ func FormatBurstList(bursts []*domain.Burst) string {
 	th := theme.Default()
 	b.WriteString(primitives.Title("Bursts", th).Render())
 	b.WriteString("\n")
-	b.WriteString(fmt.Sprintf("Total bursts: %d\n\n", len(bursts)))
+	fmt.Fprintf(&b, "Total bursts: %d\n\n", len(bursts))
 
 	for i, burst := range bursts {
 		burstName := burst.Name
 		if burstName == "" {
 			burstName = fmt.Sprintf("Burst %d", i+1)
 		}
-		b.WriteString(fmt.Sprintf("%d. %s\n", i+1, burstName))
-		b.WriteString(fmt.Sprintf("   ID: %s\n", burst.ID))
-		b.WriteString(fmt.Sprintf("   Events: %d\n", len(burst.EventIDs)))
+		fmt.Fprintf(&b, "%d. %s\n", i+1, burstName)
+		fmt.Fprintf(&b, "   ID: %s\n", burst.ID)
+		fmt.Fprintf(&b, "   Events: %d\n", len(burst.EventIDs))
 		if burst.Description != "" {
-			b.WriteString(fmt.Sprintf("   Description: %s\n", burst.Description))
+			fmt.Fprintf(&b, "   Description: %s\n", burst.Description)
 		}
 		if burst.Description != "" {
-			b.WriteString(fmt.Sprintf("   Competency Focus: %s\n", burst.Description))
+			fmt.Fprintf(&b, "   Competency Focus: %s\n", burst.Description)
 		}
-		b.WriteString(fmt.Sprintf("   Created: %s\n", burst.CreatedAt.Format("2006-01-02 15:04:05")))
+		fmt.Fprintf(&b, "   Created: %s\n", burst.CreatedAt.Format("2006-01-02 15:04:05"))
 		b.WriteString("\n")
 	}
 

--- a/internal/cli/cmd/facts/formatters.go
+++ b/internal/cli/cmd/facts/formatters.go
@@ -27,7 +27,7 @@ func FormatExtractionResults(factCount, eventCount int, competencyCount map[stri
 	var b strings.Builder
 
 	b.WriteString("\n=== Fact Extraction Results ===\n")
-	b.WriteString(fmt.Sprintf("Extracted %d facts from %d events\n\n", factCount, eventCount))
+	fmt.Fprintf(&b, "Extracted %d facts from %d events\n\n", factCount, eventCount)
 
 	if len(competencyCount) == 0 {
 		return b.String()
@@ -41,7 +41,7 @@ func FormatExtractionResults(factCount, eventCount int, competencyCount map[stri
 	sort.Strings(competencies)
 
 	for _, c := range competencies {
-		b.WriteString(fmt.Sprintf("  - %s: %d facts\n", c, competencyCount[c]))
+		fmt.Fprintf(&b, "  - %s: %d facts\n", c, competencyCount[c])
 	}
 	b.WriteString("\n")
 
@@ -65,22 +65,22 @@ func FormatFactList(facts []*domain.Fact) string {
 	th := theme.Default()
 	b.WriteString(primitives.Title("Existing Facts", th).Render())
 	b.WriteString("\n")
-	b.WriteString(fmt.Sprintf("Total facts: %d\n\n", len(facts)))
+	fmt.Fprintf(&b, "Total facts: %d\n\n", len(facts))
 
 	for i, fact := range facts {
-		b.WriteString(fmt.Sprintf("%d. %s\n", i+1, fact.Text))
-		b.WriteString(fmt.Sprintf("   ID: %s\n", fact.ID))
-		b.WriteString(fmt.Sprintf("   Source Event: %s\n", fact.SourceEventID))
+		fmt.Fprintf(&b, "%d. %s\n", i+1, fact.Text)
+		fmt.Fprintf(&b, "   ID: %s\n", fact.ID)
+		fmt.Fprintf(&b, "   Source Event: %s\n", fact.SourceEventID)
 		if len(fact.CompetencyCategories) > 0 {
-			b.WriteString(fmt.Sprintf("   Competencies: %s\n", strings.Join(fact.CompetencyCategories, ", ")))
+			fmt.Fprintf(&b, "   Competencies: %s\n", strings.Join(fact.CompetencyCategories, ", "))
 		}
 		if fact.RoleFit != "" {
-			b.WriteString(fmt.Sprintf("   Role Fit: %s\n", fact.RoleFit))
+			fmt.Fprintf(&b, "   Role Fit: %s\n", fact.RoleFit)
 		}
 		if len(fact.AudienceRelevance) > 0 {
-			b.WriteString(fmt.Sprintf("   Target Audiences: %s\n", strings.Join(fact.AudienceRelevance, ", ")))
+			fmt.Fprintf(&b, "   Target Audiences: %s\n", strings.Join(fact.AudienceRelevance, ", "))
 		}
-		b.WriteString(fmt.Sprintf("   Created: %s\n", fact.CreatedAt.Format("2006-01-02 15:04:05")))
+		fmt.Fprintf(&b, "   Created: %s\n", fact.CreatedAt.Format("2006-01-02 15:04:05"))
 		b.WriteString("\n")
 	}
 

--- a/internal/cli/cmd/import/formatters.go
+++ b/internal/cli/cmd/import/formatters.go
@@ -27,7 +27,7 @@ func FormatFailedRows(result *importer.ImportResult) string {
 	}
 
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("Failed: %d\n", result.FailedCount))
+	fmt.Fprintf(&b, "Failed: %d\n", result.FailedCount)
 
 	if len(result.FailedRows) == 0 {
 		return b.String()
@@ -41,7 +41,7 @@ func FormatFailedRows(result *importer.ImportResult) string {
 
 	for i := range maxDisplay {
 		if result.FailedRows[i].Event != nil {
-			b.WriteString(fmt.Sprintf("  - %s\n", result.FailedRows[i].Event.Text))
+			fmt.Fprintf(&b, "  - %s\n", result.FailedRows[i].Event.Text)
 		}
 	}
 
@@ -66,15 +66,15 @@ func FormatBurstSuggestions(result *importer.ImportResult) string {
 
 	var b strings.Builder
 	b.WriteString("\n=== Burst Suggestions ===\n")
-	b.WriteString(fmt.Sprintf("Detected %d potential bursts from imported events:\n\n", len(result.BurstSuggestions)))
+	fmt.Fprintf(&b, "Detected %d potential bursts from imported events:\n\n", len(result.BurstSuggestions))
 
 	for i, burst := range result.BurstSuggestions {
 		burstName := burst.Name
 		if burstName == "" {
 			burstName = fmt.Sprintf("Burst %d", i+1)
 		}
-		b.WriteString(fmt.Sprintf("%d. %s\n", i+1, burstName))
-		b.WriteString(fmt.Sprintf("   Events: %d | Confidence: %.1f%%\n", len(burst.EventIDs), burst.ConfidenceScore*100))
+		fmt.Fprintf(&b, "%d. %s\n", i+1, burstName)
+		fmt.Fprintf(&b, "   Events: %d | Confidence: %.1f%%\n", len(burst.EventIDs), burst.ConfidenceScore*100)
 	}
 	b.WriteString("\nThese bursts represent potential project groupings or themes.\n")
 
@@ -99,7 +99,7 @@ func FormatFactExtraction(result *importer.ImportResult) string {
 
 	var b strings.Builder
 	b.WriteString("\n=== Fact Extraction ===\n")
-	b.WriteString(fmt.Sprintf("Extracted %d facts from %d events\n", result.ExtractedFactsCount, len(result.CreatedEvents)))
+	fmt.Fprintf(&b, "Extracted %d facts from %d events\n", result.ExtractedFactsCount, len(result.CreatedEvents))
 
 	if len(result.FactsByCompetency) == 0 {
 		return b.String()
@@ -113,7 +113,7 @@ func FormatFactExtraction(result *importer.ImportResult) string {
 	sort.Strings(competencies)
 
 	for _, c := range competencies {
-		b.WriteString(fmt.Sprintf("  - %s: %d facts\n", c, result.FactsByCompetency[c]))
+		fmt.Fprintf(&b, "  - %s: %d facts\n", c, result.FactsByCompetency[c])
 	}
 	b.WriteString("\nThese facts highlight key competencies and achievements.\n")
 

--- a/internal/cli/components/event_detail_card.go
+++ b/internal/cli/components/event_detail_card.go
@@ -50,28 +50,28 @@ func (c *EventDetailCard) Render() string {
 	content.WriteString("\nEvent Details\n\n")
 
 	// Event header
-	content.WriteString(fmt.Sprintf("Date: %s\n", c.event.Date.Format("2006-01-02")))
+	fmt.Fprintf(&content, "Date: %s\n", c.event.Date.Format("2006-01-02"))
 
 	if c.event.Company != "" {
-		content.WriteString(fmt.Sprintf("Company: %s\n", c.event.Company))
+		fmt.Fprintf(&content, "Company: %s\n", c.event.Company)
 	}
 	if c.event.Project != "" {
-		content.WriteString(fmt.Sprintf("Project: %s\n", c.event.Project))
+		fmt.Fprintf(&content, "Project: %s\n", c.event.Project)
 	}
 
-	content.WriteString(fmt.Sprintf("\nText:\n%s\n", c.event.Text))
+	fmt.Fprintf(&content, "\nText:\n%s\n", c.event.Text)
 
 	// Tags and categories
 	if len(c.event.Tags) > 0 {
-		content.WriteString(fmt.Sprintf("\nTags: %s\n", strings.Join(c.event.Tags, ", ")))
+		fmt.Fprintf(&content, "\nTags: %s\n", strings.Join(c.event.Tags, ", "))
 	}
 	if len(c.event.Categories) > 0 {
-		content.WriteString(fmt.Sprintf("Categories: %s\n", strings.Join(c.event.Categories, ", ")))
+		fmt.Fprintf(&content, "Categories: %s\n", strings.Join(c.event.Categories, ", "))
 	}
 
 	// Skills (just show count, as we only have IDs)
 	if len(c.event.Skills) > 0 {
-		content.WriteString(fmt.Sprintf("Skills: %d associated\n", len(c.event.Skills)))
+		fmt.Fprintf(&content, "Skills: %d associated\n", len(c.event.Skills))
 	}
 
 	// Apply themed card styling

--- a/internal/cli/intents/generatecv/views.go
+++ b/internal/cli/intents/generatecv/views.go
@@ -180,17 +180,17 @@ func (i *Intent) viewExportComplete() string {
 	if i.exportError != nil {
 		errorHeader := primitives.ErrorText("Export Failed", th).Bold().Render()
 		content.WriteString("\n" + errorHeader + "\n\n")
-		content.WriteString(fmt.Sprintf("Error: %v\n\n", i.exportError))
+		fmt.Fprintf(&content, "Error: %v\n\n", i.exportError)
 		content.WriteString("Try a different location or format.\n")
 	} else {
 		successHeader := primitives.SuccessText("Export Complete!", th).Bold().Render()
 		content.WriteString("\n" + successHeader + "\n\n")
 
 		formatName := exportFormatDisplayName(i.selectedExportFormat)
-		content.WriteString(fmt.Sprintf("Format: %s\n", formatName))
+		fmt.Fprintf(&content, "Format: %s\n", formatName)
 
 		if i.selectedExportOption == ExportOptionSaveToFile {
-			content.WriteString(fmt.Sprintf("Location: %s\n\n", i.exportedPath))
+			fmt.Fprintf(&content, "Location: %s\n\n", i.exportedPath)
 			content.WriteString("You can now share this file!\n")
 		} else {
 			content.WriteString("Location: Clipboard\n\n")

--- a/internal/cli/navigation/help.go
+++ b/internal/cli/navigation/help.go
@@ -182,13 +182,13 @@ func GetGroupedHelp() string {
 
 	var result strings.Builder
 	for groupName, keys := range groups {
-		result.WriteString(fmt.Sprintf("\n%s:\n", groupName))
+		fmt.Fprintf(&result, "\n%s:\n", groupName)
 		for _, key := range keys {
 			description, exists := KeyDescription[key]
 			if !exists {
 				description = string(key)
 			}
-			result.WriteString(fmt.Sprintf("  %s → %s\n", key, description))
+			fmt.Fprintf(&result, "  %s → %s\n", key, description)
 		}
 	}
 

--- a/internal/cli/screens/base/detail_screen.go
+++ b/internal/cli/screens/base/detail_screen.go
@@ -38,9 +38,9 @@ type ContentRenderer[T any] func(data T, width, height int) string
 //
 //	renderer := func(data *EventDetail, width, height int) string {
 //	    var b strings.Builder
-//	    b.WriteString(fmt.Sprintf("Title: %s\n", data.Title))
-//	    b.WriteString(fmt.Sprintf("Description: %s\n", data.Description))
-//	    b.WriteString(fmt.Sprintf("Date: %s\n", data.Date.Format("2006-01-02")))
+//	    fmt.Fprintf(&b, "Title: %s\n", data.Title)
+//	    fmt.Fprintf(&b, "Description: %s\n", data.Description)
+//	    fmt.Fprintf(&b, "Date: %s\n", data.Date.Format("2006-01-02"))
 //	    return b.String()
 //	}
 //

--- a/internal/cli/screens/burst_management/modals/detail_modal.go
+++ b/internal/cli/screens/burst_management/modals/detail_modal.go
@@ -221,7 +221,7 @@ func renderBurstDetailContent(burst *career.Burst, theme themes.Theme) string {
 
 	// Event count.
 	b.WriteString(primitives.NewText("Events:", theme).Bold().Render())
-	b.WriteString(fmt.Sprintf(" %d\n\n", len(burst.EventIDs)))
+	fmt.Fprintf(&b, " %d\n\n", len(burst.EventIDs))
 
 	// Confirmation details.
 	if burst.Confirmed && burst.ConfirmedAt != nil {

--- a/internal/cli/screens/burst_management/modals/events_modal.go
+++ b/internal/cli/screens/burst_management/modals/events_modal.go
@@ -167,7 +167,7 @@ func renderEventsContent(events []*career.Event, theme themes.Theme) string {
 	var b strings.Builder
 
 	for idx, event := range events {
-		b.WriteString(fmt.Sprintf("%d. %s\n", idx+1, event.Text))
+		fmt.Fprintf(&b, "%d. %s\n", idx+1, event.Text)
 		dateText := "   Date: " + event.Date.Format("2006-01-02")
 		b.WriteString(primitives.NewText(dateText, theme).
 			Foreground(theme.SecondaryColor()).Render())

--- a/internal/cli/screens/burst_management/modals/facts_modal.go
+++ b/internal/cli/screens/burst_management/modals/facts_modal.go
@@ -167,7 +167,7 @@ func renderFactsContent(facts []*career.Fact, theme themes.Theme) string {
 	var b strings.Builder
 
 	for idx, fact := range facts {
-		b.WriteString(fmt.Sprintf("%d. %s\n", idx+1, fact.Text))
+		fmt.Fprintf(&b, "%d. %s\n", idx+1, fact.Text)
 
 		if len(fact.CompetencyCategories) > 0 {
 			catText := "   Categories: " + strings.Join(fact.CompetencyCategories, ", ")

--- a/internal/cli/screens/burst_management/modals/skills_modal.go
+++ b/internal/cli/screens/burst_management/modals/skills_modal.go
@@ -167,7 +167,7 @@ func renderSkillsContent(skills []*career.Skill, theme themes.Theme) string {
 	var b strings.Builder
 
 	for idx, skill := range skills {
-		b.WriteString(fmt.Sprintf("%d. %s\n", idx+1, skill.Name))
+		fmt.Fprintf(&b, "%d. %s\n", idx+1, skill.Name)
 
 		if skill.Category != "" {
 			catText := "   Category: " + skill.Category

--- a/internal/cli/screens/cv/review.go
+++ b/internal/cli/screens/cv/review.go
@@ -297,30 +297,30 @@ func (s *ReviewScreen) renderGenerationSettings() string {
 
 	if s.summary.SelectedProfile != nil && s.summary.SelectedProfile.Name != "" {
 		profileName := s.summary.SelectedProfile.Name
-		b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Profile:"), valueStyle.Render(profileName)))
+		fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("Profile:"), valueStyle.Render(profileName))
 	}
 	if s.summary.SelectedAudience != "" {
-		b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Audience:"), valueStyle.Render(s.summary.SelectedAudience)))
+		fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("Audience:"), valueStyle.Render(s.summary.SelectedAudience))
 	}
 	if s.summary.TechnologyFocus != "" {
-		b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Tech Focus:"), valueStyle.Render(s.summary.TechnologyFocus)))
+		fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("Tech Focus:"), valueStyle.Render(s.summary.TechnologyFocus))
 	}
 	if len(s.summary.Technologies) > 0 {
 		techText := strings.Join(s.summary.Technologies, ", ")
-		b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Technologies:"), valueStyle.Render(techText)))
+		fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("Technologies:"), valueStyle.Render(techText))
 	}
 	if s.summary.FocusArea != "" {
-		b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Focus Area:"), valueStyle.Render(s.summary.FocusArea)))
+		fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("Focus Area:"), valueStyle.Render(s.summary.FocusArea))
 	}
 	if s.summary.SkillsFormat != "" {
 		skillsText := s.summary.SkillsFormat
 		if s.summary.SkillsLimit > 0 {
 			skillsText = fmt.Sprintf("%s (%d max)", skillsText, s.summary.SkillsLimit)
 		}
-		b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Skills Format:"), valueStyle.Render(skillsText)))
+		fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("Skills Format:"), valueStyle.Render(skillsText))
 	}
 	if s.summary.CVLength != "" {
-		b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("CV Length:"), valueStyle.Render(s.summary.CVLength)))
+		fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("CV Length:"), valueStyle.Render(s.summary.CVLength))
 	}
 	b.WriteString("\n")
 
@@ -340,9 +340,9 @@ func (s *ReviewScreen) renderPersonalDetails() string {
 	b.WriteString("\n")
 	b.WriteString(strings.Repeat("─", minInt(60, s.width-4)))
 	b.WriteString("\n")
-	b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Name:"), valueStyle.Render(profile.Name)))
-	b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Email:"), valueStyle.Render(profile.Email)))
-	b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Location:"), valueStyle.Render(profile.Location)))
+	fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("Name:"), valueStyle.Render(profile.Name))
+	fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("Email:"), valueStyle.Render(profile.Email))
+	fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("Location:"), valueStyle.Render(profile.Location))
 	b.WriteString("\n")
 
 	return b.String()
@@ -359,9 +359,9 @@ func (s *ReviewScreen) renderCVDetails() string {
 	b.WriteString("\n")
 	b.WriteString(strings.Repeat("─", minInt(60, s.width-4)))
 	b.WriteString("\n")
-	b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("CV Name:"), valueStyle.Render(s.cv.Name)))
-	b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Role:"), valueStyle.Render(s.cv.TargetRole)))
-	b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Audience:"), valueStyle.Render(s.cv.TargetAudience)))
+	fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("CV Name:"), valueStyle.Render(s.cv.Name))
+	fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("Role:"), valueStyle.Render(s.cv.TargetRole))
+	fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("Audience:"), valueStyle.Render(s.cv.TargetAudience))
 	b.WriteString("\n")
 
 	return b.String()
@@ -378,12 +378,12 @@ func (s *ReviewScreen) renderStatistics() string {
 	b.WriteString("\n")
 	b.WriteString(strings.Repeat("─", minInt(60, s.width-4)))
 	b.WriteString("\n")
-	b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Source Events:"), valueStyle.Render(strconv.Itoa(s.cv.SourceEventCount))))
-	b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Source Facts:"), valueStyle.Render(strconv.Itoa(s.cv.SourceFactCount))))
-	b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Sections:"), valueStyle.Render(strconv.Itoa(len(s.cv.Sections)))))
+	fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("Source Events:"), valueStyle.Render(strconv.Itoa(s.cv.SourceEventCount)))
+	fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("Source Facts:"), valueStyle.Render(strconv.Itoa(s.cv.SourceFactCount)))
+	fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("Sections:"), valueStyle.Render(strconv.Itoa(len(s.cv.Sections))))
 
 	totalBullets := s.countTotalBullets()
-	b.WriteString(fmt.Sprintf("  %s %s\n", labelStyle.Render("Total Bullets:"), valueStyle.Render(strconv.Itoa(totalBullets))))
+	fmt.Fprintf(&b, "  %s %s\n", labelStyle.Render("Total Bullets:"), valueStyle.Render(strconv.Itoa(totalBullets)))
 	b.WriteString("\n")
 
 	return b.String()
@@ -460,7 +460,7 @@ func (s *ReviewScreen) renderHighlights() string {
 		if text == "" {
 			text = bullet.EnhancedText
 		}
-		b.WriteString(fmt.Sprintf("  • %s\n", valueStyle.Render(text)))
+		fmt.Fprintf(&b, "  • %s\n", valueStyle.Render(text))
 	}
 	b.WriteString("\n")
 
@@ -495,10 +495,10 @@ func (s *ReviewScreen) renderSectionsList() string {
 			typeIndicator = "  ✎"
 		}
 
-		b.WriteString(fmt.Sprintf("%s %s %s\n",
+		fmt.Fprintf(&b, "%s %s %s\n",
 			typeIndicator,
 			valueStyle.Render(section.Title),
-			labelStyle.Render(fmt.Sprintf("(%d %s)", sectionBullets, bulletText))))
+			labelStyle.Render(fmt.Sprintf("(%d %s)", sectionBullets, bulletText)))
 	}
 
 	return b.String()

--- a/internal/cli/screens/timeline/modals/helpers.go
+++ b/internal/cli/screens/timeline/modals/helpers.go
@@ -75,26 +75,26 @@ func RenderEventDetailContent(event *career.Event, theme themes.Theme) string {
 	var content strings.Builder
 	content.WriteString("\nEvent Details\n\n")
 
-	content.WriteString(fmt.Sprintf("Date: %s\n", event.Date.Format("2006-01-02")))
+	fmt.Fprintf(&content, "Date: %s\n", event.Date.Format("2006-01-02"))
 
 	if event.Company != "" {
-		content.WriteString(fmt.Sprintf("Company: %s\n", event.Company))
+		fmt.Fprintf(&content, "Company: %s\n", event.Company)
 	}
 	if event.Project != "" {
-		content.WriteString(fmt.Sprintf("Project: %s\n", event.Project))
+		fmt.Fprintf(&content, "Project: %s\n", event.Project)
 	}
 
-	content.WriteString(fmt.Sprintf("\nText:\n%s\n", event.Text))
+	fmt.Fprintf(&content, "\nText:\n%s\n", event.Text)
 
 	if len(event.Tags) > 0 {
-		content.WriteString(fmt.Sprintf("\nTags: %s\n", strings.Join(event.Tags, ", ")))
+		fmt.Fprintf(&content, "\nTags: %s\n", strings.Join(event.Tags, ", "))
 	}
 	if len(event.Categories) > 0 {
-		content.WriteString(fmt.Sprintf("Categories: %s\n", strings.Join(event.Categories, ", ")))
+		fmt.Fprintf(&content, "Categories: %s\n", strings.Join(event.Categories, ", "))
 	}
 
 	if len(event.Skills) > 0 {
-		content.WriteString(fmt.Sprintf("Skills: %d associated\n", len(event.Skills)))
+		fmt.Fprintf(&content, "Skills: %d associated\n", len(event.Skills))
 	}
 
 	return content.String()

--- a/internal/cli/statematrix/generator.go
+++ b/internal/cli/statematrix/generator.go
@@ -32,9 +32,9 @@ func generateMermaidDiagram(component ComponentInfo) string {
 
 	// Start with ROOT state or first state
 	if rootState != nil {
-		sb.WriteString(fmt.Sprintf("    [*] --> %s\n", rootState.Constant))
+		fmt.Fprintf(&sb, "    [*] --> %s\n", rootState.Constant)
 	} else if len(component.States) > 0 {
-		sb.WriteString(fmt.Sprintf("    [*] --> %s\n", component.States[0].Constant))
+		fmt.Fprintf(&sb, "    [*] --> %s\n", component.States[0].Constant)
 	}
 
 	// Add transitions based on state types
@@ -44,55 +44,55 @@ func generateMermaidDiagram(component ComponentInfo) string {
 			// ROOT can go to next state or cancel to main menu
 			if i+1 < len(component.States) {
 				nextState := component.States[i+1]
-				sb.WriteString(fmt.Sprintf("    %s --> %s : proceed\n", state.Constant, nextState.Constant))
+				fmt.Fprintf(&sb, "    %s --> %s : proceed\n", state.Constant, nextState.Constant)
 			}
-			sb.WriteString(fmt.Sprintf("    %s --> [*] : cancel\n", state.Constant))
+			fmt.Fprintf(&sb, "    %s --> [*] : cancel\n", state.Constant)
 
 		case "Intermediate":
 			// Intermediate can go forward or back
 			if i+1 < len(component.States) {
 				nextState := component.States[i+1]
-				sb.WriteString(fmt.Sprintf("    %s --> %s : proceed\n", state.Constant, nextState.Constant))
+				fmt.Fprintf(&sb, "    %s --> %s : proceed\n", state.Constant, nextState.Constant)
 			}
 			if i > 0 {
 				prevState := component.States[i-1]
-				sb.WriteString(fmt.Sprintf("    %s --> %s : back\n", state.Constant, prevState.Constant))
+				fmt.Fprintf(&sb, "    %s --> %s : back\n", state.Constant, prevState.Constant)
 			}
 
 		case "Confirmation":
 			// Confirmation can accept, reject, or cancel
 			if i+1 < len(component.States) {
 				nextState := component.States[i+1]
-				sb.WriteString(fmt.Sprintf("    %s --> %s : confirm\n", state.Constant, nextState.Constant))
+				fmt.Fprintf(&sb, "    %s --> %s : confirm\n", state.Constant, nextState.Constant)
 			}
 			if i > 0 {
 				prevState := component.States[i-1]
-				sb.WriteString(fmt.Sprintf("    %s --> %s : cancel\n", state.Constant, prevState.Constant))
+				fmt.Fprintf(&sb, "    %s --> %s : cancel\n", state.Constant, prevState.Constant)
 			}
 
 		case "Async":
 			// Async operations complete or error
 			if i+1 < len(component.States) {
 				nextState := component.States[i+1]
-				sb.WriteString(fmt.Sprintf("    %s --> %s : complete\n", state.Constant, nextState.Constant))
+				fmt.Fprintf(&sb, "    %s --> %s : complete\n", state.Constant, nextState.Constant)
 			}
 			// Look for error state
 			for j := range component.States {
 				if component.States[j].Type == "Error" {
-					sb.WriteString(fmt.Sprintf("    %s --> %s : error\n", state.Constant, component.States[j].Constant))
+					fmt.Fprintf(&sb, "    %s --> %s : error\n", state.Constant, component.States[j].Constant)
 					break
 				}
 			}
 
 		case "Final", "Error":
 			// Terminal states go to end
-			sb.WriteString(fmt.Sprintf("    %s --> [*]\n", state.Constant))
+			fmt.Fprintf(&sb, "    %s --> [*]\n", state.Constant)
 
 		case "Modal":
 			// Modals return to parent state
 			if i > 0 {
 				prevState := component.States[i-1]
-				sb.WriteString(fmt.Sprintf("    %s --> %s : close\n", state.Constant, prevState.Constant))
+				fmt.Fprintf(&sb, "    %s --> %s : close\n", state.Constant, prevState.Constant)
 			}
 		}
 	}

--- a/internal/cli/uikit/selectors/audience_relevance_selector.go
+++ b/internal/cli/uikit/selectors/audience_relevance_selector.go
@@ -81,9 +81,9 @@ func (a *AudienceRelevanceSelector) Render() string {
 	var b strings.Builder
 	for _, opt := range a.options {
 		if a.selected[opt] {
-			b.WriteString(fmt.Sprintf("[✓ %s] ", opt))
+			fmt.Fprintf(&b, "[✓ %s] ", opt)
 		} else {
-			b.WriteString(fmt.Sprintf("[ %s ] ", opt))
+			fmt.Fprintf(&b, "[ %s ] ", opt)
 		}
 	}
 	return b.String()

--- a/internal/service/career/cv/export_service.go
+++ b/internal/service/career/cv/export_service.go
@@ -232,11 +232,11 @@ func (es *ExportService) ExportToText(_ context.Context, cv *career.CVView, sect
 	buf.WriteString(strings.Repeat("=", len(cv.Name)) + "\n\n")
 
 	// Write metadata
-	buf.WriteString(fmt.Sprintf("Target Role: %s\n", cv.TargetRole))
-	buf.WriteString(fmt.Sprintf("Target Audience: %s\n", cv.TargetAudience))
-	buf.WriteString(fmt.Sprintf("Generated: %s\n", cv.GeneratedAt.Format("2006-01-02 15:04:05")))
-	buf.WriteString(fmt.Sprintf("Source Events: %d\n", cv.SourceEventCount))
-	buf.WriteString(fmt.Sprintf("Source Facts: %d\n\n", cv.SourceFactCount))
+	fmt.Fprintf(&buf, "Target Role: %s\n", cv.TargetRole)
+	fmt.Fprintf(&buf, "Target Audience: %s\n", cv.TargetAudience)
+	fmt.Fprintf(&buf, "Generated: %s\n", cv.GeneratedAt.Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(&buf, "Source Events: %d\n", cv.SourceEventCount)
+	fmt.Fprintf(&buf, "Source Facts: %d\n\n", cv.SourceFactCount)
 
 	// Write sections
 	for _, section := range sections {
@@ -260,9 +260,9 @@ func (es *ExportService) ExportToText(_ context.Context, cv *career.CVView, sect
 			if group.Header != "" {
 				if group.StartDate != "" && group.EndDate != "" {
 					if group.StartDate == group.EndDate {
-						buf.WriteString(fmt.Sprintf("%s - %s\n\n", group.Header, group.StartDate))
+						fmt.Fprintf(&buf, "%s - %s\n\n", group.Header, group.StartDate)
 					} else {
-						buf.WriteString(fmt.Sprintf("%s - %s - %s\n\n", group.Header, group.StartDate, group.EndDate))
+						fmt.Fprintf(&buf, "%s - %s - %s\n\n", group.Header, group.StartDate, group.EndDate)
 					}
 				} else {
 					buf.WriteString(group.Header + "\n\n")
@@ -271,7 +271,7 @@ func (es *ExportService) ExportToText(_ context.Context, cv *career.CVView, sect
 
 			// Write bullets
 			for _, bullet := range group.Bullets {
-				buf.WriteString(fmt.Sprintf("• %s\n", bullet.Text))
+				fmt.Fprintf(&buf, "• %s\n", bullet.Text)
 			}
 			buf.WriteString("\n")
 		}
@@ -301,17 +301,17 @@ func (es *ExportService) ExportToMarkdown(ctx context.Context, cv *career.CVView
 	var buf bytes.Buffer
 
 	// Write header
-	buf.WriteString(fmt.Sprintf("# %s\n\n", cv.Name))
+	fmt.Fprintf(&buf, "# %s\n\n", cv.Name)
 
 	// Write metadata as comment
-	buf.WriteString(fmt.Sprintf("<!-- Target Role: %s -->\n", cv.TargetRole))
-	buf.WriteString(fmt.Sprintf("<!-- Target Audience: %s -->\n", cv.TargetAudience))
-	buf.WriteString(fmt.Sprintf("<!-- Generated: %s -->\n", cv.GeneratedAt.Format("2006-01-02 15:04:05")))
-	buf.WriteString(fmt.Sprintf("<!-- Source Events: %d, Facts: %d -->\n\n", cv.SourceEventCount, cv.SourceFactCount))
+	fmt.Fprintf(&buf, "<!-- Target Role: %s -->\n", cv.TargetRole)
+	fmt.Fprintf(&buf, "<!-- Target Audience: %s -->\n", cv.TargetAudience)
+	fmt.Fprintf(&buf, "<!-- Generated: %s -->\n", cv.GeneratedAt.Format("2006-01-02 15:04:05"))
+	fmt.Fprintf(&buf, "<!-- Source Events: %d, Facts: %d -->\n\n", cv.SourceEventCount, cv.SourceFactCount)
 
 	// Write sections
 	for _, section := range sections {
-		buf.WriteString(fmt.Sprintf("## %s\n\n", section.Title))
+		fmt.Fprintf(&buf, "## %s\n\n", section.Title)
 
 		// Handle summary section (prose)
 		if section.SectionType == "summary" && section.Summary != "" {
@@ -330,18 +330,18 @@ func (es *ExportService) ExportToMarkdown(ctx context.Context, cv *career.CVView
 			if group.Header != "" {
 				if group.StartDate != "" && group.EndDate != "" {
 					if group.StartDate == group.EndDate {
-						buf.WriteString(fmt.Sprintf("### %s - _%s_\n\n", group.Header, group.StartDate))
+						fmt.Fprintf(&buf, "### %s - _%s_\n\n", group.Header, group.StartDate)
 					} else {
-						buf.WriteString(fmt.Sprintf("### %s - _%s - %s_\n\n", group.Header, group.StartDate, group.EndDate))
+						fmt.Fprintf(&buf, "### %s - _%s - %s_\n\n", group.Header, group.StartDate, group.EndDate)
 					}
 				} else {
-					buf.WriteString(fmt.Sprintf("### %s\n\n", group.Header))
+					fmt.Fprintf(&buf, "### %s\n\n", group.Header)
 				}
 			}
 
 			// Write bullets
 			for _, bullet := range group.Bullets {
-				buf.WriteString(fmt.Sprintf("- %s\n", bullet.Text))
+				fmt.Fprintf(&buf, "- %s\n", bullet.Text)
 			}
 			buf.WriteString("\n")
 		}
@@ -862,8 +862,8 @@ func (es *ExportService) exportConsultingText(ctx context.Context, cv *career.CV
 	buf.WriteString(strings.Repeat("=", len(cv.Name)) + "\n\n")
 	buf.WriteString(profile.Role + "\n")
 	buf.WriteString(profile.Location + "\n")
-	buf.WriteString(fmt.Sprintf("Email: %s\n", profile.Email))
-	buf.WriteString(fmt.Sprintf("GitHub: %s\n\n", forms.GitHubURL(profile.GitHub)))
+	fmt.Fprintf(&buf, "Email: %s\n", profile.Email)
+	fmt.Fprintf(&buf, "GitHub: %s\n\n", forms.GitHubURL(profile.GitHub))
 
 	buf.WriteString(strings.Repeat("-", 80) + "\n\n")
 
@@ -885,7 +885,7 @@ func (es *ExportService) exportConsultingText(ctx context.Context, cv *career.CV
 				// Company header with dates
 				if group.Header != "" {
 					if group.StartDate != "" && group.EndDate != "" {
-						buf.WriteString(fmt.Sprintf("%s | %s - %s\n", group.Header, group.StartDate, group.EndDate))
+						fmt.Fprintf(&buf, "%s | %s - %s\n", group.Header, group.StartDate, group.EndDate)
 					} else {
 						buf.WriteString(group.Header + "\n")
 					}
@@ -894,7 +894,7 @@ func (es *ExportService) exportConsultingText(ctx context.Context, cv *career.CV
 				// Bullets from the bullets map
 				sectionBullets := bullets[section.ID]
 				for _, bullet := range sectionBullets {
-					buf.WriteString(fmt.Sprintf("  * %s\n", bullet.Text))
+					fmt.Fprintf(&buf, "  * %s\n", bullet.Text)
 				}
 				buf.WriteString("\n")
 			}
@@ -906,7 +906,7 @@ func (es *ExportService) exportConsultingText(ctx context.Context, cv *career.CV
 		buf.WriteString("WHAT I BRING\n")
 		buf.WriteString(strings.Repeat("-", 12) + "\n\n")
 		for _, prop := range profile.ValuePropositions {
-			buf.WriteString(fmt.Sprintf("  * %s\n", prop))
+			fmt.Fprintf(&buf, "  * %s\n", prop)
 		}
 		buf.WriteString("\n")
 	}
@@ -920,9 +920,9 @@ func (es *ExportService) exportConsultingMarkdown(ctx context.Context, cv *caree
 	profile := NarrativeProfileFromConfig(profileCfg)
 
 	// Profile header
-	buf.WriteString(fmt.Sprintf("# %s\n\n", cv.Name))
-	buf.WriteString(fmt.Sprintf("**%s** | %s\n\n", profile.Role, profile.Location))
-	buf.WriteString(fmt.Sprintf("Email: %s | GitHub: %s\n\n", profile.Email, forms.GitHubURL(profile.GitHub)))
+	fmt.Fprintf(&buf, "# %s\n\n", cv.Name)
+	fmt.Fprintf(&buf, "**%s** | %s\n\n", profile.Role, profile.Location)
+	fmt.Fprintf(&buf, "Email: %s | GitHub: %s\n\n", profile.Email, forms.GitHubURL(profile.GitHub))
 	buf.WriteString("---\n\n")
 
 	// Summary section
@@ -941,16 +941,16 @@ func (es *ExportService) exportConsultingMarkdown(ctx context.Context, cv *caree
 				// Company header with dates
 				if group.Header != "" {
 					if group.StartDate != "" && group.EndDate != "" {
-						buf.WriteString(fmt.Sprintf("### %s\n*%s - %s*\n\n", group.Header, group.StartDate, group.EndDate))
+						fmt.Fprintf(&buf, "### %s\n*%s - %s*\n\n", group.Header, group.StartDate, group.EndDate)
 					} else {
-						buf.WriteString(fmt.Sprintf("### %s\n\n", group.Header))
+						fmt.Fprintf(&buf, "### %s\n\n", group.Header)
 					}
 				}
 
 				// Bullets from the bullets map
 				sectionBullets := bullets[section.ID]
 				for _, bullet := range sectionBullets {
-					buf.WriteString(fmt.Sprintf("- %s\n", bullet.Text))
+					fmt.Fprintf(&buf, "- %s\n", bullet.Text)
 				}
 				buf.WriteString("\n")
 			}
@@ -961,7 +961,7 @@ func (es *ExportService) exportConsultingMarkdown(ctx context.Context, cv *caree
 	if len(profile.ValuePropositions) > 0 {
 		buf.WriteString("## What I Bring\n\n")
 		for _, prop := range profile.ValuePropositions {
-			buf.WriteString(fmt.Sprintf("- %s\n", prop))
+			fmt.Fprintf(&buf, "- %s\n", prop)
 		}
 		buf.WriteString("\n")
 	}
@@ -1002,7 +1002,7 @@ func ExportHighlightsForAudience(view career.CVView, profile config.ProfileConfi
 
 	buf.WriteString(strings.ToUpper(view.Name) + "\n")
 	buf.WriteString(strings.Repeat("=", len(view.Name)) + "\n")
-	buf.WriteString(fmt.Sprintf("%s | %s | %s\n\n", narrative.Role, narrative.Location, narrative.Email))
+	fmt.Fprintf(&buf, "%s | %s | %s\n\n", narrative.Role, narrative.Location, narrative.Email)
 
 	summaryPrefix, hasPrefix := audienceSummaryPrefixes[audience]
 	if hasPrefix {
@@ -1024,7 +1024,7 @@ func ExportHighlightsForAudience(view career.CVView, profile config.ProfileConfi
 			maxStrengths = len(narrative.CoreStrengths)
 		}
 		for i := range maxStrengths {
-			buf.WriteString(fmt.Sprintf("  * %s\n", narrative.CoreStrengths[i]))
+			fmt.Fprintf(&buf, "  * %s\n", narrative.CoreStrengths[i])
 		}
 	} else {
 		buf.WriteString("  * Technical leadership and architecture\n")
@@ -1038,7 +1038,7 @@ func ExportHighlightsForAudience(view career.CVView, profile config.ProfileConfi
 
 	topBullets := GetTopBulletsForAudience(view, audience, 5)
 	for _, bullet := range topBullets {
-		buf.WriteString(fmt.Sprintf("  * %s\n", bullet.Text))
+		fmt.Fprintf(&buf, "  * %s\n", bullet.Text)
 	}
 	buf.WriteString("\n")
 
@@ -1046,10 +1046,10 @@ func ExportHighlightsForAudience(view career.CVView, profile config.ProfileConfi
 		buf.WriteString("TECHNOLOGIES\n")
 		buf.WriteString(strings.Repeat("-", 12) + "\n\n")
 		if len(narrative.Languages) > 0 {
-			buf.WriteString(fmt.Sprintf("Languages: %s\n", strings.Join(narrative.Languages, ", ")))
+			fmt.Fprintf(&buf, "Languages: %s\n", strings.Join(narrative.Languages, ", "))
 		}
 		if len(narrative.Systems) > 0 {
-			buf.WriteString(fmt.Sprintf("Systems: %s\n", strings.Join(narrative.Systems, ", ")))
+			fmt.Fprintf(&buf, "Systems: %s\n", strings.Join(narrative.Systems, ", "))
 		}
 		buf.WriteString("\n")
 	}
@@ -1065,7 +1065,7 @@ func (es *ExportService) exportHighlightsText(ctx context.Context, cv *career.CV
 	// Condensed profile header
 	buf.WriteString(strings.ToUpper(cv.Name) + "\n")
 	buf.WriteString(strings.Repeat("=", len(cv.Name)) + "\n")
-	buf.WriteString(fmt.Sprintf("%s | %s | %s\n\n", profile.Role, profile.Location, profile.Email))
+	fmt.Fprintf(&buf, "%s | %s | %s\n\n", profile.Role, profile.Location, profile.Email)
 
 	// Short summary
 	summary := getSummaryFromSections(sections)
@@ -1085,7 +1085,7 @@ func (es *ExportService) exportHighlightsText(ctx context.Context, cv *career.CV
 			maxStrengths = len(profile.CoreStrengths)
 		}
 		for i := range maxStrengths {
-			buf.WriteString(fmt.Sprintf("  * %s\n", profile.CoreStrengths[i]))
+			fmt.Fprintf(&buf, "  * %s\n", profile.CoreStrengths[i])
 		}
 	} else {
 		buf.WriteString("  * Technical leadership and architecture\n")
@@ -1100,7 +1100,7 @@ func (es *ExportService) exportHighlightsText(ctx context.Context, cv *career.CV
 
 	topBullets := es.getTopBulletsByConfidence(bullets, 5)
 	for _, bullet := range topBullets {
-		buf.WriteString(fmt.Sprintf("  * %s\n", bullet.Text))
+		fmt.Fprintf(&buf, "  * %s\n", bullet.Text)
 	}
 	buf.WriteString("\n")
 
@@ -1109,10 +1109,10 @@ func (es *ExportService) exportHighlightsText(ctx context.Context, cv *career.CV
 		buf.WriteString("TECHNOLOGIES\n")
 		buf.WriteString(strings.Repeat("-", 12) + "\n\n")
 		if len(profile.Languages) > 0 {
-			buf.WriteString(fmt.Sprintf("Languages: %s\n", strings.Join(profile.Languages, ", ")))
+			fmt.Fprintf(&buf, "Languages: %s\n", strings.Join(profile.Languages, ", "))
 		}
 		if len(profile.Systems) > 0 {
-			buf.WriteString(fmt.Sprintf("Systems: %s\n", strings.Join(profile.Systems, ", ")))
+			fmt.Fprintf(&buf, "Systems: %s\n", strings.Join(profile.Systems, ", "))
 		}
 		buf.WriteString("\n")
 	}
@@ -1126,8 +1126,8 @@ func (es *ExportService) exportHighlightsMarkdown(ctx context.Context, cv *caree
 	profile := NarrativeProfileFromConfig(profileCfg)
 
 	// Condensed profile header
-	buf.WriteString(fmt.Sprintf("# %s\n\n", cv.Name))
-	buf.WriteString(fmt.Sprintf("**%s** | %s | %s\n\n", profile.Role, profile.Location, profile.Email))
+	fmt.Fprintf(&buf, "# %s\n\n", cv.Name)
+	fmt.Fprintf(&buf, "**%s** | %s | %s\n\n", profile.Role, profile.Location, profile.Email)
 
 	// Short summary
 	summary := getSummaryFromSections(sections)
@@ -1145,7 +1145,7 @@ func (es *ExportService) exportHighlightsMarkdown(ctx context.Context, cv *caree
 			maxStrengths = len(profile.CoreStrengths)
 		}
 		for i := range maxStrengths {
-			buf.WriteString(fmt.Sprintf("- %s\n", profile.CoreStrengths[i]))
+			fmt.Fprintf(&buf, "- %s\n", profile.CoreStrengths[i])
 		}
 	} else {
 		buf.WriteString("- Technical leadership and architecture\n")
@@ -1158,7 +1158,7 @@ func (es *ExportService) exportHighlightsMarkdown(ctx context.Context, cv *caree
 	buf.WriteString("## Selected Highlights\n\n")
 	topBullets := es.getTopBulletsByConfidence(bullets, 5)
 	for _, bullet := range topBullets {
-		buf.WriteString(fmt.Sprintf("- %s\n", bullet.Text))
+		fmt.Fprintf(&buf, "- %s\n", bullet.Text)
 	}
 	buf.WriteString("\n")
 
@@ -1166,10 +1166,10 @@ func (es *ExportService) exportHighlightsMarkdown(ctx context.Context, cv *caree
 	if len(profile.Languages) > 0 || len(profile.Systems) > 0 {
 		buf.WriteString("## Technologies\n\n")
 		if len(profile.Languages) > 0 {
-			buf.WriteString(fmt.Sprintf("**Languages:** %s\n\n", strings.Join(profile.Languages, ", ")))
+			fmt.Fprintf(&buf, "**Languages:** %s\n\n", strings.Join(profile.Languages, ", "))
 		}
 		if len(profile.Systems) > 0 {
-			buf.WriteString(fmt.Sprintf("**Systems:** %s\n", strings.Join(profile.Systems, ", ")))
+			fmt.Fprintf(&buf, "**Systems:** %s\n", strings.Join(profile.Systems, ", "))
 		}
 		buf.WriteString("\n")
 	}
@@ -1284,9 +1284,9 @@ func (es *ExportService) exportNarrativeTextWithProfile(ctx context.Context, cv 
 	buf.WriteString(strings.Repeat("=", len(profile.Name)) + "\n\n")
 	buf.WriteString(profile.Role + "\n")
 	buf.WriteString(profile.Location + "\n")
-	buf.WriteString(fmt.Sprintf("Email: %s\n", profile.Email))
-	buf.WriteString(fmt.Sprintf("GitHub: %s\n", forms.GitHubURL(profile.GitHub)))
-	buf.WriteString(fmt.Sprintf("Portfolio: %s\n\n", profile.Portfolio))
+	fmt.Fprintf(&buf, "Email: %s\n", profile.Email)
+	fmt.Fprintf(&buf, "GitHub: %s\n", forms.GitHubURL(profile.GitHub))
+	fmt.Fprintf(&buf, "Portfolio: %s\n\n", profile.Portfolio)
 
 	buf.WriteString(strings.Repeat("-", 80) + "\n\n")
 
@@ -1304,16 +1304,16 @@ func (es *ExportService) exportNarrativeTextWithProfile(ctx context.Context, cv 
 	buf.WriteString("CORE STRENGTHS\n")
 	buf.WriteString(strings.Repeat("-", 14) + "\n\n")
 	for _, strength := range profile.CoreStrengths {
-		buf.WriteString(fmt.Sprintf("• %s\n", strength))
+		fmt.Fprintf(&buf, "• %s\n", strength)
 	}
 	buf.WriteString("\n")
 
 	// Languages & Technologies section
 	buf.WriteString("LANGUAGES & TECHNOLOGIES\n")
 	buf.WriteString(strings.Repeat("-", 24) + "\n\n")
-	buf.WriteString(fmt.Sprintf("Languages: %s\n", strings.Join(profile.Languages, ", ")))
-	buf.WriteString(fmt.Sprintf("Frontend: %s\n", strings.Join(profile.Frontend, ", ")))
-	buf.WriteString(fmt.Sprintf("Systems: %s\n\n", strings.Join(profile.Systems, ", ")))
+	fmt.Fprintf(&buf, "Languages: %s\n", strings.Join(profile.Languages, ", "))
+	fmt.Fprintf(&buf, "Frontend: %s\n", strings.Join(profile.Frontend, ", "))
+	fmt.Fprintf(&buf, "Systems: %s\n\n", strings.Join(profile.Systems, ", "))
 
 	// Selected Experience section (filtered by confidence)
 	buf.WriteString("SELECTED EXPERIENCE\n")
@@ -1332,7 +1332,7 @@ func (es *ExportService) exportNarrativeTextWithProfile(ctx context.Context, cv 
 			if group.Header != "" {
 				if group.StartDate != "" && group.EndDate != "" {
 					buf.WriteString(group.Header + "\n")
-					buf.WriteString(fmt.Sprintf("%s - %s\n\n", group.StartDate, group.EndDate))
+					fmt.Fprintf(&buf, "%s - %s\n\n", group.StartDate, group.EndDate)
 				} else {
 					buf.WriteString(group.Header + "\n\n")
 				}
@@ -1340,7 +1340,7 @@ func (es *ExportService) exportNarrativeTextWithProfile(ctx context.Context, cv 
 
 			// High-confidence bullets only
 			for _, bullet := range highConfidenceBullets {
-				buf.WriteString(fmt.Sprintf("• %s\n", bullet.Text))
+				fmt.Fprintf(&buf, "• %s\n", bullet.Text)
 			}
 			buf.WriteString("\n")
 		}
@@ -1350,7 +1350,7 @@ func (es *ExportService) exportNarrativeTextWithProfile(ctx context.Context, cv 
 	buf.WriteString("WHAT I BRING\n")
 	buf.WriteString(strings.Repeat("-", 12) + "\n\n")
 	for _, prop := range profile.ValuePropositions {
-		buf.WriteString(fmt.Sprintf("• %s\n", prop))
+		fmt.Fprintf(&buf, "• %s\n", prop)
 	}
 	buf.WriteString("\n")
 
@@ -1366,12 +1366,12 @@ func (es *ExportService) exportNarrativeMarkdownWithProfile(ctx context.Context,
 	profile := NarrativeProfileFromConfig(profileCfg)
 
 	// Profile header
-	buf.WriteString(fmt.Sprintf("# %s\n\n", profile.Name))
-	buf.WriteString(fmt.Sprintf("**%s**\n", profile.Role))
+	fmt.Fprintf(&buf, "# %s\n\n", profile.Name)
+	fmt.Fprintf(&buf, "**%s**\n", profile.Role)
 	buf.WriteString(profile.Location + "\n")
-	buf.WriteString(fmt.Sprintf("Email: [%s](mailto:%s)\n", profile.Email, profile.Email))
-	buf.WriteString(fmt.Sprintf("GitHub: %s\n", forms.GitHubURL(profile.GitHub)))
-	buf.WriteString(fmt.Sprintf("Portfolio: %s\n\n", profile.Portfolio))
+	fmt.Fprintf(&buf, "Email: [%s](mailto:%s)\n", profile.Email, profile.Email)
+	fmt.Fprintf(&buf, "GitHub: %s\n", forms.GitHubURL(profile.GitHub))
+	fmt.Fprintf(&buf, "Portfolio: %s\n\n", profile.Portfolio)
 
 	buf.WriteString("---\n\n")
 
@@ -1387,15 +1387,15 @@ func (es *ExportService) exportNarrativeMarkdownWithProfile(ctx context.Context,
 	// Core Strengths section
 	buf.WriteString("## Core Strengths\n\n")
 	for _, strength := range profile.CoreStrengths {
-		buf.WriteString(fmt.Sprintf("- %s\n", strength))
+		fmt.Fprintf(&buf, "- %s\n", strength)
 	}
 	buf.WriteString("\n")
 
 	// Languages & Technologies section
 	buf.WriteString("## Languages & Technologies\n\n")
-	buf.WriteString(fmt.Sprintf("**Languages:** %s\n", strings.Join(profile.Languages, ", ")))
-	buf.WriteString(fmt.Sprintf("**Frontend:** %s\n", strings.Join(profile.Frontend, ", ")))
-	buf.WriteString(fmt.Sprintf("**Systems:** %s\n\n", strings.Join(profile.Systems, ", ")))
+	fmt.Fprintf(&buf, "**Languages:** %s\n", strings.Join(profile.Languages, ", "))
+	fmt.Fprintf(&buf, "**Frontend:** %s\n", strings.Join(profile.Frontend, ", "))
+	fmt.Fprintf(&buf, "**Systems:** %s\n\n", strings.Join(profile.Systems, ", "))
 
 	// Selected Experience section (filtered by confidence)
 	buf.WriteString("## Selected Experience\n\n")
@@ -1412,16 +1412,16 @@ func (es *ExportService) exportNarrativeMarkdownWithProfile(ctx context.Context,
 			// Group header with dates
 			if group.Header != "" {
 				if group.StartDate != "" && group.EndDate != "" {
-					buf.WriteString(fmt.Sprintf("### %s\n", group.Header))
-					buf.WriteString(fmt.Sprintf("*%s - %s*\n\n", group.StartDate, group.EndDate))
+					fmt.Fprintf(&buf, "### %s\n", group.Header)
+					fmt.Fprintf(&buf, "*%s - %s*\n\n", group.StartDate, group.EndDate)
 				} else {
-					buf.WriteString(fmt.Sprintf("### %s\n\n", group.Header))
+					fmt.Fprintf(&buf, "### %s\n\n", group.Header)
 				}
 			}
 
 			// High-confidence bullets only
 			for _, bullet := range highConfidenceBullets {
-				buf.WriteString(fmt.Sprintf("- %s\n", bullet.Text))
+				fmt.Fprintf(&buf, "- %s\n", bullet.Text)
 			}
 			buf.WriteString("\n")
 		}
@@ -1430,7 +1430,7 @@ func (es *ExportService) exportNarrativeMarkdownWithProfile(ctx context.Context,
 	// What I Bring section
 	buf.WriteString("## What I Bring\n\n")
 	for _, prop := range profile.ValuePropositions {
-		buf.WriteString(fmt.Sprintf("- %s\n", prop))
+		fmt.Fprintf(&buf, "- %s\n", prop)
 	}
 	buf.WriteString("\n")
 

--- a/internal/service/career/skillinference/detector.go
+++ b/internal/service/career/skillinference/detector.go
@@ -372,7 +372,7 @@ func (s *DefaultSkillInferenceService) containsPattern(text string, words []stri
 		}
 
 		// Check proximity: count words between last match and current match
-		if i > 0 {
+		if i > 0 && i-1 < len(words) {
 			prevWordEnd := lastIndex + len(words[i-1])
 			currentWordStart := searchStart + index
 


### PR DESCRIPTION
## Summary

- Replace `WriteString(fmt.Sprintf(...))` with `fmt.Fprintf(...)` across 16 files to satisfy **staticcheck QF1012**
- Add bounds check in skill inference detector to resolve **gosec G602** slice index warning

## Details

All changes are purely mechanical lint fixes — zero logic changes. 17 files modified with 160 insertions and 160 deletions (balanced refactoring).

### Errors fixed

| Linter | Rule | Count | Fix |
|--------|------|-------|-----|
| staticcheck | QF1012 | ~150 instances | `b.WriteString(fmt.Sprintf(...))` → `fmt.Fprintf(&b, ...)` |
| gosec | G602 | 1 instance | Added `i-1 < len(words)` bounds check |

### Files changed

- `internal/cli/cmd/bursts/formatters.go`
- `internal/cli/cmd/facts/formatters.go`
- `internal/cli/cmd/import/formatters.go`
- `internal/cli/components/event_detail_card.go`
- `internal/cli/intents/generatecv/views.go`
- `internal/cli/navigation/help.go`
- `internal/cli/screens/base/detail_screen.go`
- `internal/cli/screens/burst_management/modals/detail_modal.go`
- `internal/cli/screens/burst_management/modals/events_modal.go`
- `internal/cli/screens/burst_management/modals/facts_modal.go`
- `internal/cli/screens/burst_management/modals/skills_modal.go`
- `internal/cli/screens/cv/review.go`
- `internal/cli/screens/timeline/modals/helpers.go`
- `internal/cli/statematrix/generator.go`
- `internal/cli/uikit/selectors/audience_relevance_selector.go`
- `internal/service/career/cv/export_service.go`
- `internal/service/career/skillinference/detector.go`

## Verification

- ✅ `golangci-lint run ./...` — 0 issues
- ✅ All existing tests pass (67 suites)
- ✅ Build succeeds
- ✅ No functional behaviour changes