### PR TITLE
docs: add YAML bullet structure breaking-change notice

### DIFF
--- a/BREAKING_CHANGES_YAML_BULLET_STRUCTURE.md
+++ b/BREAKING_CHANGES_YAML_BULLET_STRUCTURE.md
@@ -1,0 +1,35 @@
+# Breaking Change Notice: YAML CV Export Bullet Structure
+
+## What Changed
+- The YAML CV export now preserves bullet structure for `summary` and `highlights` fields as YAML lists (`[]string`).
+- Previously, these fields were exported as block strings (prose). Now, they are exported as proper YAML arrays.
+
+## Impact
+- **YAML consumers** expecting block strings for `summary` or `highlights` must update their parsers to handle lists.
+- **Text and Markdown exports** remain unchanged and unaffected by this refactor.
+
+## Migration Guidance
+- Update any downstream tools, scripts, or integrations that consume the YAML CV export to handle `summary` and `highlights` as lists.
+- Example:
+
+```yaml
+summary:
+  - "Heading text"
+  - "Bullet one summary"
+  - "Bullet two summary"
+highlights:
+  - "Highlight one"
+  - "Highlight two"
+```
+
+## Reason
+- This change ensures bullet structure is preserved for clarity and consistency across all CV export formats.
+- It aligns YAML output with Text and Markdown exports, which already treat bullets as lists.
+
+## Compatibility
+- No changes to bullet generation or scoring logic.
+- No changes to Text or Markdown export formats.
+
+---
+
+**If you rely on block string summary/highlights in YAML, update your code to handle lists.**


### PR DESCRIPTION
## Summary

Documents the breaking change where YAML CV export now preserves bullet structure as YAML lists instead of block strings. Provides migration guidance for downstream YAML consumers.

## Changes

- Added `BREAKING_CHANGES_YAML_BULLET_STRUCTURE.md` with:
  - Description of what changed (block strings → YAML arrays for `summary` and `highlights`)
  - Impact assessment for YAML consumers
  - Migration guidance with example YAML structure
  - Compatibility notes (Text/Markdown exports unaffected)

## Context

This is a documentation-only PR split from the `cv_generation_enhancements` branch to provide standalone migration guidance for downstream YAML consumers affected by the bullet structure change.

## Testing

- N/A — documentation only, no code changes