### PR TITLE
fix(lint): add go-isatty to depguard import allowlist

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -430,6 +430,7 @@ linters:
             - $gostd
             - github.com/baphled/kariya
             - github.com/charmbracelet
+            - github.com/mattn/go-isatty
             - github.com/google/uuid
             - github.com/mattn/go-sqlite3
             - modernc.org/sqlite


### PR DESCRIPTION
## Summary

Adds `github.com/mattn/go-isatty` to the depguard strict-mode import allowlist in `.golangci.yml`, enabling TTY detection code to pass lint checks.

## Changes

- Added `github.com/mattn/go-isatty` to the `main` depguard rule's `allow` list

## Context

Split from #205 (`feat(cli): launch TUI when kariya is called with no subcommand`) to isolate the lint policy change from the feature implementation. This is a prerequisite for any code that uses `go-isatty` for terminal detection.

## Testing

- No code changes; lint config only
- Existing tests unaffected